### PR TITLE
Fix to change brightness and color temperature at the same time.

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -101,7 +101,7 @@ class WyzeBulb(Light):
 		You can skip the brightness part if your light does not support
 		brightness control.
 		"""
-		self._light._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+		self._light._brightness = kwargs.get(ATTR_BRIGHTNESS)
 		self._light._colortemp = kwargs.get(ATTR_COLOR_TEMP)
 		self._light.turn_on()
 		self._state = True


### PR DESCRIPTION
I was having trouble with scenes that change the brightness and color temperature at the same time.
To recreate the issue, just make one scene at 1% brightness with warm color temp, and another scene with 100% brightness and cool color temp. Only the color temperature will change when you swap between the two scenes.

I tracked down some issues in your integration. It should be a bit cleaner and remove some duplicated code, as well as behave better hopefully. I haven't tested it very much but please look over the changes. 

Thank you for creating this integration!