### PR TITLE
Extract credentials to a single config group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,12 @@
 
 ## Configuration
 
-Add the following to your configuration file. ***Note: This will change in a future release I am expecting to integrate the platform section so you only need to include the email and password once if you use both the light and the switch. Please refer to issue [#12](https://github.com/JoshuaMulliken/ha-wyzeapi/issues/12)***
+Add the following to your configuration file. ***Note: This has changed recently. Check your configuration!***
 
 ```yaml
-light:
-  - platform: wyzeapi
-    username: <email for wyze>
-    password: <password for wyze>
-
-switch:
-  - platform: wyzeapi
-    username: <email for wyze>
-    password: <password for wyze>
-
+wyzeapi:
+  username: <email for wyze>
+  password: <password for wyze>
 ```
 
 ## Usage

--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -1,1 +1,51 @@
-"""Wyze Bulbs integration."""
+"""Wyze Bulb/Switch integration."""
+
+import logging
+
+import voluptuous as vol
+
+from .wyzeapi.wyzeapi import WyzeApi
+
+from homeassistant.const import (
+    CONF_DEVICES, CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME)
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'wyzeapi'
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+def setup(hass, config):
+    """Set up the WyzeApi parent component."""
+    _LOGGER.info("Creating new WyzeApi component")
+
+    wyzeapi_account = WyzeApi(config[DOMAIN].get(CONF_USERNAME),
+                              config[DOMAIN].get(CONF_PASSWORD))
+
+    if not wyzeapi_account.is_valid_login():
+        _LOGGER.error("Not connected to Wyze account. Unable to add devices. Check your configuration.")
+        return False
+
+    _LOGGER.info("Connected to Wyze account")
+    wyzeapi_devices = wyzeapi_account.get_devices()
+
+    # Store the logged in account object for the platforms to use.
+    hass.data[DOMAIN] = {
+        "wyzeapi_account": wyzeapi_account
+    }
+
+    # Start up lights and switch components
+    if wyzeapi_devices:
+        _LOGGER.debug("Starting WyzeApi components")
+        discovery.load_platform(hass, "light", DOMAIN, {}, config)
+        discovery.load_platform(hass, "switch", DOMAIN, {}, config)
+    else:
+        _LOGGER.error("WyzeApi authenticated but could not find any devices.")
+
+    return True

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -3,6 +3,7 @@
 """Platform for light integration."""
 import logging
 from .wyzeapi.wyzeapi import WyzeApi
+from . import DOMAIN
 
 import voluptuous as vol
 
@@ -17,16 +18,7 @@ from homeassistant.components.light import (
 	Light
 	)
 
-from homeassistant.const import CONF_DEVICE_ID, CONF_PASSWORD, CONF_USERNAME
-
 _LOGGER = logging.getLogger(__name__)
-
-# Validation of the user's configuration
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-	vol.Required(CONF_USERNAME): cv.string,
-	vol.Required(CONF_PASSWORD): cv.string,
-})
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
 	"""Set up the Awesome Light platform."""
@@ -42,19 +34,9 @@ If you have any issues with this you need to open an issue here:
 https://github.com/JoshuaMulliken/ha-wyzeapi/issues
 -------------------------------------------------------------------""")
 
-	user_name = config[CONF_USERNAME]
-	password = config.get(CONF_PASSWORD)
-
-	# Setup connection with the WyzeApi
-	wyze = WyzeApi(user_name, password)
-
-	# Verify that passed in configuration works
-	if not wyze.is_valid_login():
-		_LOGGER.error("Could not connect to Wyze Api")
-		return
 
 	# Add devices
-	add_entities(WyzeBulb(light) for light in wyze.list_bulbs())
+	add_entities(WyzeBulb(light) for light in hass.data[DOMAIN]["wyzeapi_account"].list_bulbs())
 
 class WyzeBulb(Light):
 	"""Representation of a Wyze Bulb."""
@@ -113,7 +95,6 @@ class WyzeBulb(Light):
 
 	def update(self):
 		"""Fetch new state data for this light.
-
 		This is the only method that should fetch new data for Home Assistant.
 		"""
 		self._light.update()

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -3,6 +3,7 @@
 """Platform for switch integration."""
 import logging
 from .wyzeapi.wyzeapi import WyzeApi
+from . import DOMAIN
 
 import voluptuous as vol
 
@@ -13,36 +14,16 @@ from homeassistant.components.switch import (
 	SwitchDevice
 	)
 
-from homeassistant.const import CONF_DEVICE_ID, CONF_PASSWORD, CONF_USERNAME
-
 _LOGGER = logging.getLogger(__name__)
 
-# Validation of the user's configuration
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-	vol.Required(CONF_USERNAME): cv.string,
-	vol.Required(CONF_PASSWORD): cv.string,
-})
-
-
 def setup_platform(hass, config, add_entities, discovery_info=None):
-	"""Set up the Awesome Switch platform."""
+	"""Set up the Wyze Switch platform."""
 	# Assign configuration variables.
 	# The configuration check takes care they are present.
 	_LOGGER.debug("WYZEAPI v0.2.0")
 
-	user_name = config[CONF_USERNAME]
-	password = config.get(CONF_PASSWORD)
-
-	# Setup connection with the WyzeApi
-	wyze = WyzeApi(user_name, password)
-
-	# Verify that passed in configuration works
-	if not wyze.is_valid_login():
-		_LOGGER.error("Could not connect to Wyze Api")
-		return
-
 	# Add devices
-	add_entities(WyzeSwitch(switch) for switch in wyze.list_switches())
+	add_entities(WyzeSwitch(switch) for switch in hass.data[DOMAIN]["wyzeapi_account"].list_switches())
 
 class WyzeSwitch(SwitchDevice):
 	"""Representation of a Wyze Switch."""
@@ -64,8 +45,7 @@ class WyzeSwitch(SwitchDevice):
 		return self._state
 
 	def turn_on(self, **kwargs):
-		"""Instruct the switch to turn on.
-		"""
+		"""Instruct the switch to turn on."""
 
 		self._switch.turn_on()
 		self._state = True
@@ -77,7 +57,6 @@ class WyzeSwitch(SwitchDevice):
 
 	def update(self):
 		"""Fetch new state data for this switch.
-
 		This is the only method that should fetch new data for Home Assistant.
 		"""
 		self._switch.update()


### PR DESCRIPTION
I extracted the authentication logic to the init file and now load in the platform files properly only after the api has authenticated and has discovered devices. I wasn't sure how to properly test this stuff but it looks like the test files only test the api implementation and not anything to do with how home assistant is configured.

# THIS IS A BREAKING CHANGE

(just to be clear ;) )

The new way to configure this plugin would be:

```
wyzeapi:
  username: !secret wyzeapi_un
  password: !secret wyzeapi_pw
```

instead of 

```
light:
  - platform: wyzeapi
    username: !secret wyzeapi_un
    password: !secret wyzeapi_pw

switch:
  - platform: wyzeapi
    username: !secret wyzeapi_un
    password: !secret wyzeapi_pw
```

I've tested this on my local HA install on a raspberry pi and it's working great after quite a few reboots and tests.

This PR closes #12 