### PR TITLE
Add version to manifest (required since HA 2021.3)

### DIFF
--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -7,5 +7,6 @@
     "@joshuamulliken"
   ],
   "requirements": [],
-  "icons": []
+  "icons": [],
+  "version": "2021.3.1"
 }


### PR DESCRIPTION
As per https://www.home-assistant.io/blog/2021/03/03/release-20213/#breaking-changes