### PR TITLE
Outdoor Plug: remove unnecessary third switch

### DIFF
--- a/custom_components/wyzeapi/wyzeapi/client.py
+++ b/custom_components/wyzeapi/wyzeapi/client.py
@@ -281,7 +281,7 @@ class WyzeApiClient:
                                                  device['device_params']['switch_state'],
                                                  device['device_params']['rssi'], device['device_params']['ssid'],
                                                  device['device_params']['ip']))
-                    elif device['product_type'] == "Plug" or device['product_type'] == "OutdoorPlug":
+                    elif device['product_type'] == "Plug" or (device['product_type'] == "OutdoorPlug" and device['product_model'].endswith("-SUB")):
                         self.__switches.append(Switch(device['nickname'], device['product_model'], device['mac'],
                                                       device['device_params']['switch_state'],
                                                       device['device_params']['rssi'],


### PR DESCRIPTION
I added my new Outdoor Plug today and discovered switch.front_yard1, switch.front_yard2, and switch.wyze_outdoor_plug.  However, switch.wyze_outdoor_plug did not toggle either of the two relays, so it appears to be an unintended entity.

This is a quick fix to remove the non-functional third switch which only required minor change to the logic in custom_components/wyzeapi/wyzeapi/client.py. I have tested it on my perrsonal Home Assistant 2021.3.4.

Notes:
* The outdoor plugs have two relays.
* product_model is "WLPPO", however the relays both have a model of "WLPPO-SUB".