### PR TITLE
Add support for using cameras as motion sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 # Secrets
 secrets.py
 wyzeconfig.ini
+/.idea/

--- a/.idea/ha-wyzeapi.iml
+++ b/.idea/ha-wyzeapi.iml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    <content url="file://$MODULE_DIR$/../ha-wyzeapi">
+      <excludeFolder url="file://$MODULE_DIR$/../ha-wyzeapi/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Pipenv (ha-wyzeapi)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Pipenv (ha-wyzeapi) (2)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Pipenv (ha-wyzeapi)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Pipenv (ha-wyzeapi) (2)" project-jdk-type="Python SDK" />
 </project>

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -504,11 +504,11 @@
         },
         "wyzeapy": {
             "hashes": [
-                "sha256:b0f2592e3f645666fc677573c5e6da14487a24972cc34f1bb4a8dc62b8f83094",
-                "sha256:dceda93db7d047cefe438d2cf6baf9105b4282b9fad3e57cea4c9119c6bc8a06"
+                "sha256:43c94bb26a05f08889461c52b3616d7b43ebc81ee9bd323f58326ae2fbfee564",
+                "sha256:e8f578927e1af11e43c48b3305b4f059523dd5331f6c8cd9b190e977540253ba"
             ],
             "index": "pypi",
-            "version": "==0.0.14"
+            "version": "==0.0.15"
         },
         "yarl": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,46 +18,46 @@
     "default": {
         "aiohttp": {
             "hashes": [
-                "sha256:119feb2bd551e58d83d1b38bfa4cb921af8ddedec9fad7183132db334c3133e0",
-                "sha256:16d0683ef8a6d803207f02b899c928223eb219111bd52420ef3d7a8aa76227b6",
-                "sha256:2eb3efe243e0f4ecbb654b08444ae6ffab37ac0ef8f69d3a2ffb958905379daf",
-                "sha256:2ffea7904e70350da429568113ae422c88d2234ae776519549513c8f217f58a9",
-                "sha256:40bd1b101b71a18a528ffce812cc14ff77d4a2a1272dfb8b11b200967489ef3e",
-                "sha256:418597633b5cd9639e514b1d748f358832c08cd5d9ef0870026535bd5eaefdd0",
-                "sha256:481d4b96969fbfdcc3ff35eea5305d8565a8300410d3d269ccac69e7256b1329",
-                "sha256:4c1bdbfdd231a20eee3e56bd0ac1cd88c4ff41b64ab679ed65b75c9c74b6c5c2",
-                "sha256:5563ad7fde451b1986d42b9bb9140e2599ecf4f8e42241f6da0d3d624b776f40",
-                "sha256:58c62152c4c8731a3152e7e650b29ace18304d086cb5552d317a54ff2749d32a",
-                "sha256:5b50e0b9460100fe05d7472264d1975f21ac007b35dcd6fd50279b72925a27f4",
-                "sha256:5d84ecc73141d0a0d61ece0742bb7ff5751b0657dab8405f899d3ceb104cc7de",
-                "sha256:5dde6d24bacac480be03f4f864e9a67faac5032e28841b00533cd168ab39cad9",
-                "sha256:5e91e927003d1ed9283dee9abcb989334fc8e72cf89ebe94dc3e07e3ff0b11e9",
-                "sha256:62bc216eafac3204877241569209d9ba6226185aa6d561c19159f2e1cbb6abfb",
-                "sha256:6c8200abc9dc5f27203986100579fc19ccad7a832c07d2bc151ce4ff17190076",
-                "sha256:6ca56bdfaf825f4439e9e3673775e1032d8b6ea63b8953d3812c71bd6a8b81de",
-                "sha256:71680321a8a7176a58dfbc230789790639db78dad61a6e120b39f314f43f1907",
-                "sha256:7c7820099e8b3171e54e7eedc33e9450afe7cd08172632d32128bd527f8cb77d",
-                "sha256:7dbd087ff2f4046b9b37ba28ed73f15fd0bc9f4fdc8ef6781913da7f808d9536",
-                "sha256:822bd4fd21abaa7b28d65fc9871ecabaddc42767884a626317ef5b75c20e8a2d",
-                "sha256:8ec1a38074f68d66ccb467ed9a673a726bb397142c273f90d4ba954666e87d54",
-                "sha256:950b7ef08b2afdab2488ee2edaff92a03ca500a48f1e1aaa5900e73d6cf992bc",
-                "sha256:99c5a5bf7135607959441b7d720d96c8e5c46a1f96e9d6d4c9498be8d5f24212",
-                "sha256:b84ad94868e1e6a5e30d30ec419956042815dfaea1b1df1cef623e4564c374d9",
-                "sha256:bc3d14bf71a3fb94e5acf5bbf67331ab335467129af6416a437bd6024e4f743d",
-                "sha256:c2a80fd9a8d7e41b4e38ea9fe149deed0d6aaede255c497e66b8213274d6d61b",
-                "sha256:c44d3c82a933c6cbc21039326767e778eface44fca55c65719921c4b9661a3f7",
-                "sha256:cc31e906be1cc121ee201adbdf844522ea3349600dd0a40366611ca18cd40e81",
-                "sha256:d5d102e945ecca93bcd9801a7bb2fa703e37ad188a2f81b1e65e4abe4b51b00c",
-                "sha256:dd7936f2a6daa861143e376b3a1fb56e9b802f4980923594edd9ca5670974895",
-                "sha256:dee68ec462ff10c1d836c0ea2642116aba6151c6880b688e56b4c0246770f297",
-                "sha256:e76e78863a4eaec3aee5722d85d04dcbd9844bc6cd3bfa6aa880ff46ad16bfcb",
-                "sha256:eab51036cac2da8a50d7ff0ea30be47750547c9aa1aa2cf1a1b710a1827e7dbe",
-                "sha256:f4496d8d04da2e98cc9133e238ccebf6a13ef39a93da2e87146c8c8ac9768242",
-                "sha256:fbd3b5e18d34683decc00d9a360179ac1e7a320a5fee10ab8053ffd6deab76e0",
-                "sha256:feb24ff1226beeb056e247cf2e24bba5232519efb5645121c4aea5b6ad74c1f2"
+                "sha256:02f46fc0e3c5ac58b80d4d56eb0a7c7d97fcef69ace9326289fb9f1955e65cfe",
+                "sha256:0563c1b3826945eecd62186f3f5c7d31abb7391fedc893b7e2b26303b5a9f3fe",
+                "sha256:114b281e4d68302a324dd33abb04778e8557d88947875cbf4e842c2c01a030c5",
+                "sha256:14762875b22d0055f05d12abc7f7d61d5fd4fe4642ce1a249abdf8c700bf1fd8",
+                "sha256:15492a6368d985b76a2a5fdd2166cddfea5d24e69eefed4630cbaae5c81d89bd",
+                "sha256:17c073de315745a1510393a96e680d20af8e67e324f70b42accbd4cb3315c9fb",
+                "sha256:209b4a8ee987eccc91e2bd3ac36adee0e53a5970b8ac52c273f7f8fd4872c94c",
+                "sha256:230a8f7e24298dea47659251abc0fd8b3c4e38a664c59d4b89cca7f6c09c9e87",
+                "sha256:2e19413bf84934d651344783c9f5e22dee452e251cfd220ebadbed2d9931dbf0",
+                "sha256:393f389841e8f2dfc86f774ad22f00923fdee66d238af89b70ea314c4aefd290",
+                "sha256:3cf75f7cdc2397ed4442594b935a11ed5569961333d49b7539ea741be2cc79d5",
+                "sha256:3d78619672183be860b96ed96f533046ec97ca067fd46ac1f6a09cd9b7484287",
+                "sha256:40eced07f07a9e60e825554a31f923e8d3997cfc7fb31dbc1328c70826e04cde",
+                "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf",
+                "sha256:4b302b45040890cea949ad092479e01ba25911a15e648429c7c5aae9650c67a8",
+                "sha256:515dfef7f869a0feb2afee66b957cc7bbe9ad0cdee45aec7fdc623f4ecd4fb16",
+                "sha256:547da6cacac20666422d4882cfcd51298d45f7ccb60a04ec27424d2f36ba3eaf",
+                "sha256:5df68496d19f849921f05f14f31bd6ef53ad4b00245da3195048c69934521809",
+                "sha256:64322071e046020e8797117b3658b9c2f80e3267daec409b350b6a7a05041213",
+                "sha256:7615dab56bb07bff74bc865307aeb89a8bfd9941d2ef9d817b9436da3a0ea54f",
+                "sha256:79ebfc238612123a713a457d92afb4096e2148be17df6c50fb9bf7a81c2f8013",
+                "sha256:7b18b97cf8ee5452fa5f4e3af95d01d84d86d32c5e2bfa260cf041749d66360b",
+                "sha256:932bb1ea39a54e9ea27fc9232163059a0b8855256f4052e776357ad9add6f1c9",
+                "sha256:a00bb73540af068ca7390e636c01cbc4f644961896fa9363154ff43fd37af2f5",
+                "sha256:a5ca29ee66f8343ed336816c553e82d6cade48a3ad702b9ffa6125d187e2dedb",
+                "sha256:af9aa9ef5ba1fd5b8c948bb11f44891968ab30356d65fd0cc6707d989cd521df",
+                "sha256:bb437315738aa441251214dad17428cafda9cdc9729499f1d6001748e1d432f4",
+                "sha256:bdb230b4943891321e06fc7def63c7aace16095be7d9cf3b1e01be2f10fba439",
+                "sha256:c6e9dcb4cb338d91a73f178d866d051efe7c62a7166653a91e7d9fb18274058f",
+                "sha256:cffe3ab27871bc3ea47df5d8f7013945712c46a3cc5a95b6bee15887f1675c22",
+                "sha256:d012ad7911653a906425d8473a1465caa9f8dea7fcf07b6d870397b774ea7c0f",
+                "sha256:d9e13b33afd39ddeb377eff2c1c4f00544e191e1d1dee5b6c51ddee8ea6f0cf5",
+                "sha256:e4b2b334e68b18ac9817d828ba44d8fcb391f6acb398bcc5062b14b2cbeac970",
+                "sha256:e54962802d4b8b18b6207d4a927032826af39395a3bd9196a5af43fc4e60b009",
+                "sha256:f705e12750171c0ab4ef2a3c76b9a4024a62c4103e3a55dd6f99265b9bc6fcfc",
+                "sha256:f881853d2643a29e643609da57b96d5f9c9b93f62429dcc1cbb413c7d07f0e1a",
+                "sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.7.4"
+            "version": "==3.7.4.post0"
         },
         "astral": {
             "hashes": [
@@ -76,11 +76,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==19.3.0"
+            "version": "==20.3.0"
         },
         "awesomeversion": {
             "hashes": [
@@ -165,10 +165,11 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "ciso8601": {
             "hashes": [
@@ -206,11 +207,11 @@
         },
         "homeassistant": {
             "hashes": [
-                "sha256:aedadd2416f9fdb8787f34bfaa19f4123b642acc45dc4c78fed79550b630763b",
-                "sha256:fedcef096e10bd52f504fc86ac8888d750f49056077cba1a0e3b0efe596d385f"
+                "sha256:2897f73c8e0d1431000fb229bac0aff083c64300d0dbc395828df876134cc7a6",
+                "sha256:d946ead2a7298b0659fc4cc70a50376b107447fe9de39c2cb3bc79aeff380b59"
             ],
             "index": "pypi",
-            "version": "==2021.3.4"
+            "version": "==2021.4.3"
         },
         "httpcore": {
             "hashes": [
@@ -222,11 +223,11 @@
         },
         "httpx": {
             "hashes": [
-                "sha256:126424c279c842738805974687e0518a94c7ae8d140cd65b9c4f77ac46ffa537",
-                "sha256:9cffb8ba31fac6536f2c8cde30df859013f59e4bcc5b8d43901cb3654a8e0a5b"
+                "sha256:cc2a55188e4b25272d2bcd46379d300f632045de4377682aa98a8a6069d55967",
+                "sha256:d379653bd457e8257eb0df99cb94557e4aac441b7ba948e333be969298cac272"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.16.1"
+            "version": "==0.17.1"
         },
         "idna": {
             "hashes": [
@@ -503,11 +504,11 @@
         },
         "wyzeapy": {
             "hashes": [
-                "sha256:ae8811df281414e683d095a783676e991cd71f4e25677e58e42b3ccf948e7e07",
-                "sha256:e15cd8cbabe47ad330b1028795e4eabbd81a7628c31bb8533a242d17cf26a963"
+                "sha256:b0f2592e3f645666fc677573c5e6da14487a24972cc34f1bb4a8dc62b8f83094",
+                "sha256:dceda93db7d047cefe438d2cf6baf9105b4282b9fad3e57cea4c9119c6bc8a06"
             ],
             "index": "pypi",
-            "version": "==0.0.7"
+            "version": "==0.0.14"
         },
         "yarl": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -30,36 +30,11 @@ After you have done that if you feel like my work has been valuable to you I wel
    repository as Type: Integration
 3. Click install under "Wyze Bulb and Switch Api Integration" in the Integration tab
 4. Restart HA
-
-## Installation (Manual)
-
-1. Download this repository as a ZIP (green button, top right) and unzip the archive
-2. Copy `/custom_components/wyzeapi` to your `<config_dir>/` directory
-    * On Hassio the final location will be `/config/custom_components/wyzeapi`
-    * On Hassbian the final location will be `/home/homeassistant/.homeassistant/custom_components/wyzeapi`
-3. Restart HA
-
-## Configuration
-
-Add the following to your configuration file. ***Note: This has changed recently. Check your configuration!***
-
-```yaml
-wyzeapi:
-  username: <email for wyze>
-  password: <password for wyze>
-```
-
-You can exclude any of the devices.
-
-```yaml
-wyzeapi:
-  username: <email for wyze>
-  password: <password for wyze>
-  sensors: false
-  light: false
-  switch: false
-  lock: false
-```
+5. Navigate to _Integrations_ in the config interface. TK add image
+6. Click _ADD INTEGRATION_
+7. Search for _Wyze Home Assistant Integration_
+8. Put the email for wyze in the first box and your password in the second
+9. Click _SUBMIT_ and profit!
 
 ## Usage
 

--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -1,74 +1,95 @@
-"""Wyze Bulb/Switch integration."""
+"""The Wyze Home Assistant Integration integration."""
+from __future__ import annotations
 
+import asyncio
 import logging
 
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
-from homeassistant.const import (
-    CONF_PASSWORD, CONF_USERNAME)
-from wyzeapy.base_client import AccessTokenError
+from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.check_config import HomeAssistantConfig
 from wyzeapy.client import Client
 
+from .const import DOMAIN
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+
+PLATFORMS = ["light", "switch", "binary_sensor"]
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'wyzeapi'
-VERSION = '2021.4.10'
-CONF_SENSORS = "sensors"
-CONF_LIGHT = "light"
-CONF_SWITCH = "switch"
-CONF_LOCK = "lock"
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_SENSORS, default=True): cv.boolean,
-        vol.Optional(CONF_LIGHT, default=True): cv.boolean,
-        vol.Optional(CONF_SWITCH, default=True): cv.boolean,
-        vol.Optional(CONF_LOCK, default=True): cv.boolean
-    })
-}, extra=vol.ALLOW_EXTRA)
+async def async_setup(hass: HomeAssistant, config: HomeAssistantConfig, discovery_info=None):
+    # pylint: disable=unused-argument
+    """Set up the Alexa domain."""
+    if DOMAIN not in config:
+        _LOGGER.debug(
+            "Nothing to import from configuration.yaml, loading from Integrations",
+        )
+        return True
+
+    domainconfig = config.get(DOMAIN)
+    entry_found = False
+    _LOGGER.debug(
+        "Importing config information for {} from configuration.yml".format(domainconfig[CONF_USERNAME])
+    )
+    if hass.config_entries.async_entries(DOMAIN):
+        _LOGGER.debug("Found existing config entries")
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if (
+                    entry.data.get(CONF_USERNAME) == domainconfig[CONF_USERNAME]
+                    and entry.data.get(CONF_PASSWORD) == domainconfig[CONF_PASSWORD]
+            ):
+                _LOGGER.debug("Updating existing entry")
+                hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        CONF_USERNAME: domainconfig[CONF_USERNAME],
+                        CONF_PASSWORD: domainconfig[CONF_PASSWORD],
+                    },
+                )
+                entry_found = True
+                break
+    if not entry_found:
+        _LOGGER.debug("Creating new config entry")
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data={
+                    CONF_USERNAME: domainconfig[CONF_USERNAME],
+                    CONF_PASSWORD: domainconfig[CONF_PASSWORD],
+                },
+            )
+        )
+    return True
 
 
-def setup(hass, config):
-    """Set up the WyzeApi parent component."""
-    _LOGGER.debug("""-------------------------------------------------------------------
-Wyze Home Assistant Integration
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Wyze Home Assistant Integration from a config entry."""
 
-Version: {}
-This is a custom integration
-If you have any issues with this than please open an issue here:
-https://github.com/JoshuaMulliken/ha-wyzeapi/issues
--------------------------------------------------------------------""".format(VERSION))
-    _LOGGER.debug("""Creating new WyzeApi component""")
+    def setup_hass_data():
+        hass.data[DOMAIN][entry.entry_id] = Client(entry.data.get(CONF_USERNAME), entry.data.get(CONF_PASSWORD))
 
-    light_support = config[DOMAIN].get(CONF_LIGHT)
-    switch_support = config[DOMAIN].get(CONF_SWITCH)
-    camera_motion_support = config[DOMAIN].get(CONF_SENSORS)
+    hass.data.setdefault(DOMAIN, {})
+    await hass.async_add_executor_job(setup_hass_data)
 
-    wyzeapi_client = Client(config[DOMAIN].get(CONF_USERNAME), config[DOMAIN].get(CONF_PASSWORD))
-    _LOGGER.debug("Connected to Wyze account")
-
-    try:
-        devices = wyzeapi_client.get_devices()
-    except AccessTokenError as e:
-        _LOGGER.warning(e)
-        wyzeapi_client.reauthenticate()
-        devices = wyzeapi_client.get_devices()
-
-    # Store the logged in account object for the platforms to use.
-    hass.data[DOMAIN] = {
-        "wyzeapi_client": wyzeapi_client,
-        "devices": devices
-    }
-
-    # Start up lights and switch components
-    _LOGGER.debug("Starting WyzeApi integrations")
-    if light_support:
-        hass.helpers.discovery.load_platform("light", DOMAIN, {}, config)
-    if switch_support:
-        hass.helpers.discovery.load_platform("switch", DOMAIN, {}, config)
-    if camera_motion_support:
-        hass.helpers.discovery.load_platform("binary_sensor", DOMAIN, {}, config)
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
 
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -12,7 +12,7 @@ from wyzeapy.client import Client
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'wyzeapi'
-VERSION = '2021.4.7'
+VERSION = '2021.4.10'
 CONF_SENSORS = "sensors"
 CONF_LIGHT = "light"
 CONF_SWITCH = "switch"
@@ -44,6 +44,7 @@ https://github.com/JoshuaMulliken/ha-wyzeapi/issues
 
     light_support = config[DOMAIN].get(CONF_LIGHT)
     switch_support = config[DOMAIN].get(CONF_SWITCH)
+    camera_motion_support = config[DOMAIN].get(CONF_SENSORS)
 
     wyzeapi_client = Client(config[DOMAIN].get(CONF_USERNAME), config[DOMAIN].get(CONF_PASSWORD))
     _LOGGER.debug("Connected to Wyze account")
@@ -62,12 +63,12 @@ https://github.com/JoshuaMulliken/ha-wyzeapi/issues
     }
 
     # Start up lights and switch components
-    _LOGGER.debug("Starting WyzeApi components")
+    _LOGGER.debug("Starting WyzeApi integrations")
     if light_support:
-        _LOGGER.debug("Starting WyzeApi Lights")
         hass.helpers.discovery.load_platform("light", DOMAIN, {}, config)
     if switch_support:
-        _LOGGER.debug("Starting WyzeApi switches")
         hass.helpers.discovery.load_platform("switch", DOMAIN, {}, config)
+    if camera_motion_support:
+        hass.helpers.discovery.load_platform("binary_sensor", DOMAIN, {}, config)
 
     return True

--- a/custom_components/wyzeapi/binary_sensor.py
+++ b/custom_components/wyzeapi/binary_sensor.py
@@ -14,7 +14,7 @@ from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
-SCAN_INTERVAL = timedelta(seconds=5)
+SCAN_INTERVAL = timedelta(seconds=10)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/custom_components/wyzeapi/binary_sensor.py
+++ b/custom_components/wyzeapi/binary_sensor.py
@@ -1,0 +1,107 @@
+import logging
+import time
+from datetime import timedelta
+
+from homeassistant.const import ATTR_ATTRIBUTION
+from wyzeapy.base_client import DeviceTypes, Device, AccessTokenError, PropertyIDs
+from wyzeapy.client import Client
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    DEVICE_CLASS_MOTION
+)
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+ATTRIBUTION = "Data provided by Wyze"
+SCAN_INTERVAL = timedelta(seconds=5)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+    _ = config
+    # We only want this platform to be set up via discovery.
+    if discovery_info is None:
+        return
+
+    _LOGGER.debug("""Creating new WyzeApi binary_sensor component""")
+    wyzeapi_client: Client = hass.data[DOMAIN]['wyzeapi_client']
+    devices = hass.data[DOMAIN]['devices']
+
+    cameras = []
+    for device in devices:
+        try:
+            device_type = DeviceTypes(device.product_type)
+            if device_type == DeviceTypes.CAMERA:
+                cameras.append(WyzeCameraMotion(wyzeapi_client, device))
+        except ValueError as e:
+            _LOGGER.warning("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
+
+    add_entities(cameras, True)
+
+
+class WyzeCameraMotion(BinarySensorEntity):
+    _on: bool
+    _available: bool
+
+    def __init__(self, wyzeapi_client: Client, device: Device):
+        self._client = wyzeapi_client
+        self._device = device
+        self._last_event = int(str(int(time.time())) + "000")
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    @property
+    def name(self):
+        """Return the display name of this switch."""
+        return self._device.nickname
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._on
+
+    @property
+    def unique_id(self):
+        return self._device.mac
+
+    @property
+    def device_state_attributes(self):
+        """Return device attributes of the entity."""
+        return {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            "state": self.is_on,
+            "available": self.available,
+            "device model": self._device.product_model,
+            "mac": self.unique_id
+        }
+
+    @property
+    def device_class(self):
+        return DEVICE_CLASS_MOTION
+
+    def update(self):
+        try:
+            device_info = self._client.get_info(self._device)
+        except AccessTokenError:
+            self._client.reauthenticate()
+            device_info = self._client.get_info(self._device)
+
+        for property_id, value in device_info:
+            if property_id == PropertyIDs.AVAILABLE:
+                self._available = True if value == "1" else False
+
+        latest_event = self._client.get_latest_event(self._device)
+        if latest_event is not None:
+            if latest_event.event_ts > self._last_event:
+                self._on = True
+                self._last_event = latest_event.event_ts
+            else:
+                self._on = False
+                self._last_event = latest_event.event_ts
+        else:
+            self._on = False
+
+

--- a/custom_components/wyzeapi/config_flow.py
+++ b/custom_components/wyzeapi/config_flow.py
@@ -1,0 +1,92 @@
+"""Config flow for Wyze Home Assistant Integration integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from wyzeapy.base_client import BaseClient
+
+from .const import DOMAIN
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema({CONF_USERNAME: str, CONF_PASSWORD: str})
+
+
+async def validate_input(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+
+    # If your PyPI package is not built with async, pass your methods
+    # to the executor:
+    # await hass.async_add_executor_job(
+    #     your_validate_func, data["username"], data["password"]
+    # )
+    base_client = BaseClient()
+
+    if not await hass.async_add_executor_job(
+        base_client.can_login, data[CONF_USERNAME], data[CONF_PASSWORD]
+    ):
+        raise InvalidAuth
+
+    # If you cannot connect:
+    # throw CannotConnect
+    # If the authentication is wrong:
+    # InvalidAuth
+
+    # Return info that you want to store in the config entry.
+    return {"title": "Wyze Home Assistant Integration"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Wyze Home Assistant Integration."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(
+        self, user_input: Dict[str, Any] = None
+    ) -> Dict[str, Any]:
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Wyze Home Assistant Integration integration."""
+
+DOMAIN = "wyzeapi"

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -3,7 +3,7 @@
 """Platform for light integration."""
 import logging
 # Import the device class from the component that you want to support
-from typing import Any
+from typing import Any, List
 
 import homeassistant.util.color as color_util
 from homeassistant.components.light import (
@@ -19,36 +19,43 @@ from homeassistant.const import ATTR_ATTRIBUTION
 from wyzeapy.base_client import AccessTokenError, Device, DeviceTypes, PropertyIDs
 from wyzeapy.client import Client
 
-from . import DOMAIN
+from .const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the sensor platform."""
-    _ = config
-    # We only want this platform to be set up via discovery.
-    if discovery_info is None:
-        return
-
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
     _LOGGER.debug("""Creating new WyzeApi light component""")
-    wyzeapi_client: Client = hass.data[DOMAIN]['wyzeapi_client']
-    devices = hass.data[DOMAIN]['devices']
+    client = hass.data[DOMAIN][config_entry.entry_id]
+
+    def get_devices() -> List[Device]:
+        try:
+            devices = client.get_devices()
+        except AccessTokenError as e:
+            _LOGGER.warning(e)
+            client.reauthenticate()
+            devices = client.get_devices()
+
+        return devices
+
+    devices = await hass.async_add_executor_job(get_devices)
 
     lights = []
     color_lights = []
     for device in devices:
         try:
             if DeviceTypes(device.product_type) == DeviceTypes.LIGHT:
-                lights.append(WyzeLight(wyzeapi_client, device))
+                lights.append(WyzeLight(client, device))
             if DeviceTypes(device.product_type) == DeviceTypes.MESH_LIGHT:
-                color_lights.append(WyzeColorLight(wyzeapi_client, device))
+                color_lights.append(WyzeColorLight(client, device))
         except ValueError as e:
             _LOGGER.warning("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
 
-    add_entities(lights, True)
-    add_entities(color_lights, True)
+    async_add_entities(lights, True)
+    async_add_entities(color_lights, True)
 
 
 class WyzeLight(LightEntity):

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             if DeviceTypes(device.product_type) == DeviceTypes.MESH_LIGHT:
                 color_lights.append(WyzeColorLight(wyzeapi_client, device))
         except ValueError as e:
-            _LOGGER.warn("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
+            _LOGGER.warning("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
 
     add_entities(lights, True)
     add_entities(color_lights, True)

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -7,8 +7,8 @@
     "@joshuamulliken"
   ],
   "requirements": [
-    "wyzeapy==0.0.13"
+    "wyzeapy==0.0.14"
   ],
   "icons": [],
-  "version": "2021.4"
+  "version": "2021.4.10"
 }

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -1,14 +1,13 @@
 {
   "domain": "wyzeapi",
-  "name": "Wyze Bulb and Switch Api Integration",
-  "documentation": "https://github.com/JoshuaMulliken/ha-wyzebulb/blob/master/README.md",
+  "version": "2021.4.10",
+  "name": "Wyze Home Assistant Integration",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/wyze",
+  "requirements": ["wyzeapy==0.0.15"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
   "dependencies": [],
-  "codeowners": [
-    "@joshuamulliken"
-  ],
-  "requirements": [
-    "wyzeapy==0.0.14"
-  ],
-  "icons": [],
-  "version": "2021.4.10"
+  "codeowners": ["@JoshuaMulliken"]
 }

--- a/custom_components/wyzeapi/strings.json
+++ b/custom_components/wyzeapi/strings.json
@@ -1,0 +1,22 @@
+{
+  "title": "Wyze Home Assistant Integration",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -24,7 +24,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if discovery_info is None:
         return
 
-    _LOGGER.debug("""Creating new WyzeApi light component""")
+    _LOGGER.debug("""Creating new WyzeApi switch component""")
     wyzeapi_client: Client = hass.data[DOMAIN]['wyzeapi_client']
     devices = hass.data[DOMAIN]['devices']
 
@@ -36,7 +36,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             if DeviceTypes(device.product_type) == DeviceTypes.OUTDOOR_PLUG:
                 plugs.append(WyzeSwitch(wyzeapi_client, device))
         except ValueError as e:
-            _LOGGER.warn("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
+            _LOGGER.warning("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
 
     add_entities(plugs, True)
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -3,7 +3,7 @@
 """Platform for switch integration."""
 import logging
 # Import the device class from the component that you want to support
-from typing import Any
+from typing import Any, List
 
 from homeassistant.components.switch import (
     SwitchEntity)
@@ -12,33 +12,40 @@ from wyzeapy.base_client import AccessTokenError, DeviceTypes, Device, PropertyI
 from wyzeapy.client import Client
 
 from . import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the sensor platform."""
-    _ = config
-    # We only want this platform to be set up via discovery.
-    if discovery_info is None:
-        return
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
+    _LOGGER.debug("""Creating new WyzeApi light component""")
+    client = hass.data[DOMAIN][config_entry.entry_id]
 
-    _LOGGER.debug("""Creating new WyzeApi switch component""")
-    wyzeapi_client: Client = hass.data[DOMAIN]['wyzeapi_client']
-    devices = hass.data[DOMAIN]['devices']
+    def get_devices() -> List[Device]:
+        try:
+            devices = client.get_devices()
+        except AccessTokenError as e:
+            _LOGGER.warning(e)
+            client.reauthenticate()
+            devices = client.get_devices()
+
+        return devices
+
+    devices = await hass.async_add_executor_job(get_devices)
 
     plugs = []
     for device in devices:
         try:
             if DeviceTypes(device.product_type) == DeviceTypes.PLUG:
-                plugs.append(WyzeSwitch(wyzeapi_client, device))
+                plugs.append(WyzeSwitch(client, device))
             if DeviceTypes(device.product_type) == DeviceTypes.OUTDOOR_PLUG:
-                plugs.append(WyzeSwitch(wyzeapi_client, device))
+                plugs.append(WyzeSwitch(client, device))
         except ValueError as e:
             _LOGGER.warning("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
 
-    add_entities(plugs, True)
+    async_add_entities(plugs, True)
 
 
 class WyzeSwitch(SwitchEntity):

--- a/custom_components/wyzeapi/translations/en.json
+++ b/custom_components/wyzeapi/translations/en.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password",
+                    "username": "Username"
+                }
+            }
+        }
+    },
+    "title": "Wyze Home Assistant Integration"
+}

--- a/info.md
+++ b/info.md
@@ -7,6 +7,7 @@ note this mimics the Wyze app and therefore access may be cut off at anytime.
 
 * Control all types of Wyze Bulbs as lights through HA
 * Control all types of Wyze Plugs as switches through HA
+* Use cameras as motion sensors
 
 ## Support
 


### PR DESCRIPTION
See: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/122

Why: Cameras publish events when they detect motion. This could be used
to trigger automations in Home Assistant for a variety of interesting
uses.

How: By querying the get_event_list endpoint with a cameras mac we can
get a list of events that have occurred in the last bit of time

Tags: new features #wyze
Signed-off-by: Joshua Mulliken <joshua@mulliken.net>