### PR TITLE
Support for turning Wyzecam on and off. Note, needs updates to wyzeap…

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -44,6 +44,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                 plugs.append(WyzeSwitch(client, device))
             if DeviceTypes(device.product_type) == DeviceTypes.OUTDOOR_PLUG:
                 plugs.append(WyzeSwitch(client, device))
+            if DeviceTypes(device.product_type) == DeviceTypes.CAMERA:
+                plugs.append(WyzeSwitch(client, device))
         except ValueError as e:
             _LOGGER.warning("{}: Please report this error to https://github.com/JoshuaMulliken/ha-wyzeapi".format(e))
 


### PR DESCRIPTION
For this to work, wyzeapy needs to be updated. Based on 0.0.19, please change the following:

**base_client.py**
Add the following function
```
    def run_action(self, device: Device, action):
        if DeviceTypes(device.product_type) not in [
            DeviceTypes.CAMERA
        ]:
            raise ActionNotSupported(device.product_type)

        payload = {
            "phone_system_type": PHONE_SYSTEM_TYPE,
            "app_version": APP_VERSION,
            "app_ver": APP_VER,
            "sc": "9f275790cab94a72bd206c8876429f3c",
            "ts": int(time.time()),
            "sv": "9d74946e652647e9b6c9d59326aef104",
            "access_token": self.access_token,
            "phone_id": PHONE_ID,
            "app_name": APP_NAME,
            "provider_key": device.product_model,
            "instance_id": device.mac,
            "action_key": action,
            "action_params": {},
            "custom_string": "",
        }

        response_json = requests.post("https://api.wyzecam.com/app/v2/auto/run_action", json=payload).json()

        self.check_for_errors(response_json)

```

**client.py**
Modify the following functions with the code below
```
    def turn_on...

        elif device_type in [
            DeviceTypes.CAMERA
        ]:
            self.client.run_action(device, "power_on")
```
```
    def turn_off...

        elif device_type in [
            DeviceTypes.CAMERA
        ]:
            self.client.run_action(device, "power_off")
```