### PR TITLE
State follows WORKING_STATE

### DIFF
--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -255,7 +255,7 @@ class WyzeThermostat(ClimateEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
+            "state": self._working_state,
             "available": self.available,
             "device_model": self._device.product_model,
             "mac": self.unique_id


### PR DESCRIPTION
Change to STATE attribute to follow _working_state so NODE RED NODE - EVENTS STATE can trigger on when the HVAC is in operation.  This will also place the current HVAC ACTION in the default lovelace card, and add HA logbook entries when the HVAC goes from idle to cooling or heating.