### PR TITLE
Fix Permission denied wyze_config.ini

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     mac_addresses = await client.unique_device_ids
 
     def get_uid():
-        config_path = os.path.dirname(os.path.abspath(__file__)) + os.sep + 'wyze_config.ini'
+        config_path = hass.config.path('wyze_config.ini')
 
         config = configparser.ConfigParser()
         config.read(config_path)

--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     mac_addresses = await client.unique_device_ids
 
     def get_uid():
-        config_path = os.getcwd() + os.sep + 'wyze_config.ini'
+        config_path = os.path.dirname(os.path.abspath(__file__)) + os.sep + 'wyze_config.ini'
 
         config = configparser.ConfigParser()
         config.read(config_path)

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -4,6 +4,7 @@
 import configparser
 import logging
 # Import the device class from the component that you want to support
+import os
 import uuid
 from datetime import timedelta
 from typing import Any, Callable, List, Union
@@ -48,7 +49,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 
     def get_uid():
         config = configparser.ConfigParser()
-        config.read('wyze_config.ini')
+        config_path = os.path.dirname(os.path.abspath(__file__)) + os.sep + 'wyze_config.ini'
+        config.read(config_path)
         if config.has_option("OPTIONS", "SYSTEM_ID"):
             return config["OPTIONS"]["SYSTEM_ID"]
         else:
@@ -56,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
             config["OPTIONS"] = {}
             config["OPTIONS"]["SYSTEM_ID"] = new_uid
 
-            with open('wyze_config.ini', 'w') as configfile:
+            with open(config_path, 'w') as configfile:
                 config.write(configfile)
 
             return new_uid

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 
     def get_uid():
         config = configparser.ConfigParser()
-        config_path = os.path.dirname(os.path.abspath(__file__)) + os.sep + 'wyze_config.ini'
+        config_path = hass.config.path('wyze_config.ini')
         config.read(config_path)
         if config.has_option("OPTIONS", "SYSTEM_ID"):
             return config["OPTIONS"]["SYSTEM_ID"]


### PR DESCRIPTION
In Home Assistant Core, the current path is wrong because "ha" can't write.

With this change now wyze_config.ini will move to custom_component/wyzeapi/wyze_config.ini

This should work for all versions