### PR TITLE
228 Support for WCO, Lock, and Keypad Battery levels to be displayed

### DIFF
--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -123,8 +123,9 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
             "mac": self.unique_id
         }
 
+        # Add the lock battery value if it exists
         if self._lock.raw_dict.get("power"):
-            dev_info["battery"] = str(self._lock.raw_dict.get("power")) + "%"
+            dev_info["lock battery"] = str(self._lock.raw_dict.get("power")) + "%"
 
         return dev_info
 

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -127,6 +127,10 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
         if self._lock.raw_dict.get("power"):
             dev_info["lock battery"] = str(self._lock.raw_dict.get("power")) + "%"
 
+        # Add the keypad's battery value if it exists
+        if self._lock.raw_dict.get("keypad", {}).get("power"):
+            dev_info["keypad battery"] = str(self._lock.raw_dict.get("keypad", {}).get("power")) + "%"
+
         return dev_info
 
     @property

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -114,7 +114,7 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
     @property
     def device_state_attributes(self):
         """Return device attributes of the entity."""
-        return {
+        dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "state": self.state,
             "available": self.available,
@@ -122,6 +122,11 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
             "device_model": self._lock.product_model,
             "mac": self.unique_id
         }
+
+        if self._lock.raw_dict.get("power"):
+            dev_info["battery"] = str(self._lock.raw_dict.get("power")) + "%"
+
+        return dev_info
 
     @property
     def supported_features(self):

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -229,7 +229,13 @@ class WyzeSwitch(SwitchEntity):
         }
 
         if self._device.device_params.get("electricity"):
-            dev_info["battery"] = str(self._device.device_params.get("electricity") + "%")
+            dev_info["Battery"] = str(self._device.device_params.get("electricity") + "%")
+        if self._device.device_params.get("ip"):
+            dev_info["IP"] = str(self._device.device_params.get("ip"))
+        if self._device.device_params.get("rssi"):
+            dev_info["RSSI"] = str(self._device.device_params.get("rssi"))
+        if self._device.device_params.get("ssid"):
+            dev_info["SSID"] = str(self._device.device_params.get("ssid"))
 
         return dev_info
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -220,13 +220,18 @@ class WyzeSwitch(SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return device attributes of the entity."""
-        return {
+        dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "state": self.is_on,
             "available": self.available,
             "device model": self._device.product_model,
             "mac": self.unique_id
         }
+
+        if self._device.device_params.get("electricity"):
+            dev_info["battery"] = str(self._device.device_params.get("electricity") + "%")
+
+        return dev_info
 
     @token_exception_handler
     async def async_update(self):


### PR DESCRIPTION
This change depends on WyzeAapy [PR#20](https://github.com/JoshuaMulliken/wyzeapy/pull/20).

Display battery levels in the device attributes for the Wyze Cam Outdoors, lock, and keypad. These will be updated every 20 mintues per the changes in WyzeApy PR 20.