### PR TITLE
feat : 145 - LightEntity: add IP, RSSI, SSID to state attributes

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -180,13 +180,22 @@ class WyzeLight(LightEntity):
     @property
     def device_state_attributes(self):
         """Return device attributes of the entity."""
-        return {
+        dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "state": self.is_on,
             "available": self.available,
             "device model": self._bulb.product_model,
             "mac": self.unique_id
         }
+
+        if self._bulb.device_params.get("ip"):
+            dev_info["IP"] = str(self._bulb.device_params.get("ip"))
+        if self._bulb.device_params.get("rssi"):
+            dev_info["RSSI"] = str(self._bulb.device_params.get("rssi"))
+        if self._bulb.device_params.get("ssid"):
+            dev_info["SSID"] = str(self._bulb.device_params.get("ssid"))
+
+        return dev_info
 
     @property
     def brightness(self):


### PR DESCRIPTION
LightEntity: add IP, RSSI, SSID to state attributes

Add IP, RSSI, SSID to the LightEntity's state attributes to support feature request: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/145