### PR TITLE
Bugfix: update manger copy paste errors from self._device

### DIFF
--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -312,7 +312,7 @@ class WyzeThermostat(ClimateEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to update events."""
         self._thermostat.callback_function = self.async_update_callback
-        self._thermostat_service.register_updater(self._device, 30)
+        self._thermostat_service.register_updater(self._thermostat, 30)
         await self._thermostat_service.start_update_manager()
         return await super().async_added_to_hass()
 

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -244,7 +244,7 @@ class WyzeLight(LightEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to update events."""
         self._bulb.callback_function = self.async_update_callback
-        self._bulb_service.register_updater(self._device, 30)
+        self._bulb_service.register_updater(self._bulb, 30)
         await self._bulb_service.start_update_manager()
         return await super().async_added_to_hass()
 


### PR DESCRIPTION
This was a simply copy/paste issue, switches have self._device these have self._bulb and self._thermostat