### PR TITLE
bugfix: switches: make sure that we update the state machine on toggle

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -192,6 +192,7 @@ class WyzeSwitch(SwitchEntity):
 
         self._device.on = True
         self._just_updated = True
+        self.async_schedule_update_ha_state()
 
     @token_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -199,6 +200,7 @@ class WyzeSwitch(SwitchEntity):
 
         self._device.on = False
         self._just_updated = True
+        self.async_schedule_update_ha_state()
 
     @property
     def name(self):


### PR DESCRIPTION
Since we changed how we're handling updates, we need to update the state machine here so that the toggle reflects properly.

fixes: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/276