### PR TITLE
feat: fire event for camera events

### DIFF
--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -6,3 +6,6 @@ CONF_CLIENT = "wyzeapi_client"
 ACCESS_TOKEN = "access_token"
 REFRESH_TOKEN = "refresh_token"
 REFRESH_TIME = "refresh_time"
+
+#EVENT NAMES
+WYZE_CAMERA_EVENT = "wyze_camera_event"


### PR DESCRIPTION
This is a preliminary pull request. It will need some time in beta probably to see if users are getting what they need from it. The event data will be provided as a dict structured as follows:

name: wyze_camera_event

data will be provided as a dictionary: 
device_name: nickname of device
device_mac : mac address of device
ai_tag_list: list of any AI tags that were provided
tag_list: list of any tags that were provided
event_screenshot: url containing the screenshot
event_video: url containing the video
raw_event: an Event object from WyzeAPY


Should address the request in: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/226