### PR TITLE
chore: cleanup old entities

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -35,7 +35,7 @@ async def async_setup(
     hass: HomeAssistant, config: HomeAssistantConfig, discovery_info=None
 ):
     # pylint: disable=unused-argument
-    """Set up the Alexa domain."""
+    """Set up the WyzeApi domain."""
     if hass.config_entries.async_entries(DOMAIN):
         _LOGGER.debug(
             "Nothing to import from configuration.yaml, loading from Integrations",
@@ -110,8 +110,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             token,
         )
     except:
-        _LOGGER.error("Wyzeapi: Could not login. Please re-login through integration configuration.")
-        raise ConfigEntryAuthFailed("Unable to login, please re-login.")
+        _LOGGER.error("Wyzeapi: Could not login. Please re-login through integration configuration")
+        raise ConfigEntryAuthFailed("Unable to login, please re-login.") from None
 
     hass.data[DOMAIN][config_entry.entry_id] = {CONF_CLIENT: client}
 
@@ -134,10 +134,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         device_registry, config_entry.entry_id
     ):
         for identifier in device.identifiers:
+            # domain has to remain here. If it is removed the integration will remove all entities for not being in the mac address list each boot.
             domain, mac = identifier
             if mac not in mac_addresses:
                 _LOGGER.warning(
-                    f"{mac} is not in the mac_addresses list. Removing the entry..."
+                    '%s is not in the mac_addresses list, removing the entry', mac
                 )
                 device_registry.async_remove_device(device.id)
     return True

--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -26,6 +26,7 @@ PLATFORMS = [
     "lock",
     "climate",
     "alarm_control_panel",
+    "sensor"
 ]  # Fixme: Re add scene
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     mac_addresses = await client.unique_device_ids
 
-    mac_addresses.add(config_entry.data.get(WYZE_NOTIFICATION_TOGGLE))
+    mac_addresses.add(WYZE_NOTIFICATION_TOGGLE)
 
     hms_service = await client.hms_service
     hms_id = hms_service.hms_id

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -6,7 +6,8 @@ CONF_CLIENT = "wyzeapi_client"
 ACCESS_TOKEN = "access_token"
 REFRESH_TOKEN = "refresh_token"
 REFRESH_TIME = "refresh_time"
-UUID = "uuid"
+
+WYZE_NOTIFICATION_TOGGLE = f"{DOMAIN}.wyze.notification.toggle"
 
 LOCK_UPDATED = f"{DOMAIN}.lock_updated"
 CAMERA_UPDATED = f"{DOMAIN}.camera_updated"

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -10,3 +10,5 @@ UUID = "uuid"
 
 LOCK_UPDATED = f"{DOMAIN}.lock_updated"
 CAMERA_UPDATED = f"{DOMAIN}.camera_updated"
+#EVENT NAMES
+WYZE_CAMERA_EVENT = "wyze_camera_event"

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -6,6 +6,7 @@ CONF_CLIENT = "wyzeapi_client"
 ACCESS_TOKEN = "access_token"
 REFRESH_TOKEN = "refresh_token"
 REFRESH_TIME = "refresh_time"
+UUID = "uuid"
 
 LOCK_UPDATED = f"{DOMAIN}.lock_updated"
 CAMERA_UPDATED = f"{DOMAIN}.camera_updated"

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -7,4 +7,5 @@ ACCESS_TOKEN = "access_token"
 REFRESH_TOKEN = "refresh_token"
 REFRESH_TIME = "refresh_time"
 
-LOCK_UPDATED = "lock_updated"
+LOCK_UPDATED = f"{DOMAIN}.lock_updated"
+CAMERA_UPDATED = f"{DOMAIN}.camera_updated"

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -6,3 +6,5 @@ CONF_CLIENT = "wyzeapi_client"
 ACCESS_TOKEN = "access_token"
 REFRESH_TOKEN = "refresh_token"
 REFRESH_TIME = "refresh_time"
+
+LOCK_UPDATED = "lock_updated"

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -1,21 +1,23 @@
 #!/usr/bin/python3
 
 """Platform for light integration."""
-import logging
 from abc import ABC
 from datetime import timedelta
-from typing import Callable, List, Any
+import logging
+from typing import Any, Callable, List
+
+from wyzeapy import LockService, Wyzeapy
+from wyzeapy.services.lock_service import Lock
+from wyzeapy.types import DeviceTypes
 
 import homeassistant.components.lock
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant, callback
-from wyzeapy import Wyzeapy, LockService
-from wyzeapy.services.lock_service import Lock
-from wyzeapy.types import DeviceTypes
-from .token_manager import token_exception_handler
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, CONF_CLIENT
+from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED
+from .token_manager import token_exception_handler
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
@@ -155,6 +157,11 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
     def async_update_callback(self, lock: Lock):
         """Update the switch's state."""
         self._lock = lock
+        async_dispatcher_send(
+            self.hass,
+            f"{LOCK_UPDATED}-{self._lock.mac}",
+            lock,
+        )
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Callable, List
 
 from wyzeapy import Wyzeapy
+from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.lock_service import Lock
 
 from homeassistant.components.sensor import SensorEntity
@@ -14,11 +15,12 @@ from homeassistant.const import ATTR_ATTRIBUTION, DEVICE_CLASS_BATTERY, PERCENTA
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED
+from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED, CAMERA_UPDATED
 from .token_manager import token_exception_handler
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
+CAMERAS_WITH_BATTERIES = ["WVOD1"]
 
 @token_exception_handler
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
@@ -36,12 +38,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 
     # Get the list of locks so that we can create lock and keypad battery sensors
     lock_service = await client.lock_service
+    camera_service = await client.camera_service
 
     locks = await lock_service.get_locks()
     sensors = []
     for lock in locks:
         sensors.append(WyzeLockBatterySensor(lock, WyzeLockBatterySensor.LOCK_BATTERY))
         sensors.append(WyzeLockBatterySensor(lock, WyzeLockBatterySensor.KEYPAD_BATTERY))
+
+    cameras = await camera_service.get_cameras()
+    for camera in cameras:
+        if camera.product_model in CAMERAS_WITH_BATTERIES:
+            sensors.append(WyzeCameraBatterySensor(camera))
 
     async_add_entities(sensors, True)
 
@@ -133,3 +141,59 @@ class WyzeLockBatterySensor(SensorEntity):
             return str(self._lock.raw_dict.get("keypad", {}).get("power"))
         return 0
 
+class WyzeCameraBatterySensor(SensorEntity):
+    """Representation of a Wyze Camera Battery"""
+    _attr_device_class = DEVICE_CLASS_BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, camera):
+        self._camera = camera
+
+    @callback
+    def handle_camera_update(self, camera: Camera) -> None:
+        self._camera = camera
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{CAMERA_UPDATED}-{self._camera.mac}",
+                self.handle_camera_update,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return f"{self._camera.nickname} Battery"
+
+    @property
+    def unique_id(self):
+        return f"{self._camera.nickname}.battery"
+
+    @property
+    def should_poll(self) -> bool:
+        return False
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (DOMAIN, self._camera.mac)
+            },
+            "name": f"{self._camera.nickname}.battery",
+            "type": "camera.battery"
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return device attributes of the entity."""
+        return {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            "available": self.available,
+            "device model": f"{self._camera.product_model}.battery",
+        }
+
+    @property
+    def native_value(self):
+        return self._camera.device_params.get("electricity")

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+"""Platform for sensor integration."""
+
+import logging
+from typing import Any, Callable, List
+
+from wyzeapy import Wyzeapy
+from wyzeapy.services.lock_service import Lock
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION, DEVICE_CLASS_BATTERY, PERCENTAGE
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED
+from .token_manager import token_exception_handler
+
+_LOGGER = logging.getLogger(__name__)
+ATTRIBUTION = "Data provided by Wyze"
+
+@token_exception_handler
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
+                            async_add_entities: Callable[[List[Any], bool], None]) -> None:
+    """
+    This function sets up the config_entry
+
+    :param hass: Home Assistant instance
+    :param config_entry: The current config_entry
+    :param async_add_entities: This function adds entities to the config_entry
+    :return:
+    """
+    _LOGGER.debug("""Creating new WyzeApi sensor component""")
+    client: Wyzeapy = hass.data[DOMAIN][config_entry.entry_id][CONF_CLIENT]
+
+    # Get the list of locks so that we can create lock and keypad battery sensors
+    lock_service = await client.lock_service
+
+    locks = await lock_service.get_locks()
+    sensors = []
+    for lock in locks:
+        sensors.append(WyzeLockBatterySensor(lock, WyzeLockBatterySensor.LOCK_BATTERY))
+        sensors.append(WyzeLockBatterySensor(lock, WyzeLockBatterySensor.KEYPAD_BATTERY))
+
+    async_add_entities(sensors, True)
+
+class WyzeLockBatterySensor(SensorEntity):
+    """Representation of a Wyze Lock or Lock Keypad Battery"""
+    LOCK_BATTERY = "lock_battery"
+    KEYPAD_BATTERY = "keypad_battery"
+
+    _attr_device_class = DEVICE_CLASS_BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    # make the battery unavailable by default, this will be toggled after the first upate from the battery entity that has battery data.
+    _available = False
+
+    def __init__(self, lock, battery_type):
+        self._lock = lock
+        self._battery_type = battery_type
+
+    @callback
+    def handle_lock_update(self, lock: Lock) -> None:
+        self._lock = lock
+        if self._lock.raw_dict.get("power") and self._battery_type == self.LOCK_BATTERY:
+            self._available = True
+        if self._lock.raw_dict.get("keypad", {}).get("power") and self._battery_type == self.KEYPAD_BATTERY:
+            if self.enabled is False:
+                self.enabled = True
+            self._available = True
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{LOCK_UPDATED}-{self._lock.mac}",
+                self.handle_lock_update,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        battery_type = self._battery_type.replace("_", " ").title()
+        return f"{self._lock.nickname} {battery_type}"
+
+    @property
+    def unique_id(self):
+        return f"{self._lock.nickname}.{self._battery_type}"
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    @property
+    def should_poll(self) -> bool:
+        return False
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._battery_type == self.KEYPAD_BATTERY:
+            # The keypad battery may not be available if the lock has no keypad
+            return False
+        # The battery voltage will always be available for the lock
+        return True
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (DOMAIN, self._lock.mac)
+            },
+            "name": f"{self._lock.nickname}.{self._battery_type}",
+            "type": f"lock.{self._battery_type}"
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return device attributes of the entity."""
+        return {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            "available": self.available,
+            "device model": f"{self._lock.product_model}.{self._battery_type}",
+        }
+
+    @property
+    def native_value(self):
+        """Return the state of the device."""
+        if self._battery_type == self.LOCK_BATTERY:
+            return str(self._lock.raw_dict.get("power"))
+        elif (self._battery_type == self.KEYPAD_BATTERY):
+            return str(self._lock.raw_dict.get("keypad", {}).get("power"))
+        return 0
+

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -8,7 +8,6 @@ import logging
 # Import the device class from the component that you want to support
 import os
 from typing import Any, Callable, List, Union
-import uuid
 
 from wyzeapy import CameraService, SwitchService, Wyzeapy
 from wyzeapy.services.camera_service import Camera
@@ -24,7 +23,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import CAMERA_UPDATED, CONF_CLIENT, DOMAIN
 from .token_manager import token_exception_handler
 
-from .const import DOMAIN, CONF_CLIENT, UUID, WYZE_CAMERA_EVENT
+from .const import DOMAIN, CONF_CLIENT, WYZE_CAMERA_EVENT, WYZE_NOTIFICATION_TOGGLE
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
@@ -53,18 +52,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                                     await switch_service.get_switches()]
     switches.extend([WyzeSwitch(camera_service, switch) for switch in await camera_service.get_cameras()])
 
-    uid = config_entry.data.get(UUID)
-
-    switches.append(WyzeNotifications(client, uid))
+    switches.append(WyzeNotifications(client))
 
     async_add_entities(switches, True)
 
 
 class WyzeNotifications(SwitchEntity):
-    def __init__(self, client: Wyzeapy, uid):
+    def __init__(self, client: Wyzeapy):
         self._client = client
         self._is_on = False
-        self._uid = uid
+        self._uid = WYZE_NOTIFICATION_TOGGLE
         self._just_updated = False
 
     @property
@@ -84,7 +81,8 @@ class WyzeNotifications(SwitchEntity):
                 (DOMAIN, self._uid)
             },
             "name": "Wyze Notifications",
-            "manufacturer": "WyzeLabs"
+            "manufacturer": "WyzeLabs",
+            "model": "WyzeNotificationToggle"
         }
 
     @property

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -24,6 +24,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import CAMERA_UPDATED, CONF_CLIENT, DOMAIN
 from .token_manager import token_exception_handler
 
+from .const import DOMAIN, CONF_CLIENT, UUID
+
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -51,23 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                                     await switch_service.get_switches()]
     switches.extend([WyzeSwitch(camera_service, switch) for switch in await camera_service.get_cameras()])
 
-    def get_uid():
-        config = configparser.ConfigParser()
-        config_path = hass.config.path('wyze_config.ini')
-        config.read(config_path)
-        if config.has_option("OPTIONS", "SYSTEM_ID"):
-            return config["OPTIONS"]["SYSTEM_ID"]
-        else:
-            new_uid = uuid.uuid4().hex
-            config["OPTIONS"] = {}
-            config["OPTIONS"]["SYSTEM_ID"] = new_uid
-
-            with open(config_path, 'w') as configfile:
-                config.write(configfile)
-
-            return new_uid
-
-    uid = await hass.async_add_executor_job(get_uid)
+    uid = config_entry.data.get(UUID)
 
     switches.append(WyzeNotifications(client, uid))
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -2,25 +2,27 @@
 
 """Platform for switch integration."""
 import configparser
+from datetime import timedelta
 import logging
+
 # Import the device class from the component that you want to support
 import os
-import uuid
-from datetime import timedelta
 from typing import Any, Callable, List, Union
+import uuid
 
-from homeassistant.components.switch import (
-    SwitchEntity)
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.core import HomeAssistant, callback
-from wyzeapy import Wyzeapy, CameraService, SwitchService
+from wyzeapy import CameraService, SwitchService, Wyzeapy
 from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.switch_service import Switch
 from wyzeapy.types import Device
-from .token_manager import token_exception_handler
 
-from . import DOMAIN, CONF_CLIENT
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import CAMERA_UPDATED, CONF_CLIENT, DOMAIN
+from .token_manager import token_exception_handler
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
@@ -258,6 +260,11 @@ class WyzeSwitch(SwitchEntity):
     def async_update_callback(self, switch: Switch):
         """Update the switch's state."""
         self._device = switch
+        async_dispatcher_send(
+            self.hass,
+            f"{CAMERA_UPDATED}-{switch.mac}",
+            switch,
+        )
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
since binary sensors were disabled, some people may have hanging entities. This PR provides functionality to always cleanup our entities if things lose support in the future for whatever reason. This also has a function to get rid of the duplicate notification toggle given the change to the UUID in https://github.com/JoshuaMulliken/ha-wyzeapi/pull/280

CAUTION:
This needs additional testing before merging as it is performing destructive functions in the entity_registry. It worked fine in my devcontainer testbed, but it could have negative effects on live systems.