### PR TITLE
feat: Remove "%" from lock batteries for easier usage

### DIFF
--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -129,11 +129,11 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
 
         # Add the lock battery value if it exists
         if self._lock.raw_dict.get("power"):
-            dev_info["lock battery"] = str(self._lock.raw_dict.get("power")) + "%"
+            dev_info["lock battery"] = str(self._lock.raw_dict.get("power"))
 
         # Add the keypad's battery value if it exists
         if self._lock.raw_dict.get("keypad", {}).get("power"):
-            dev_info["keypad battery"] = str(self._lock.raw_dict.get("keypad", {}).get("power")) + "%"
+            dev_info["keypad battery"] = str(self._lock.raw_dict.get("keypad", {}).get("power"))
 
         return dev_info
 


### PR DESCRIPTION
Per issue: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/333 concatentating a percent symbol to these values causes issues in NodeRed.

This should have no breaking changes as any scripts/integrations that were using these likely just stripped the "%" from the value. Those scripts would simply be doing an unnecessary strip call without the symbol.