### PR TITLE
Update siren to use extra_state_attributes

### DIFF
--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -97,7 +97,7 @@ class WyzeCameraSiren(SirenEntity):
         return f"{self._device.mac}-siren"
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,


### PR DESCRIPTION
Fixes the waring:

`Entity siren.****_***_siren (<class 'custom_components.wyzeapi.siren.WyzeCameraSiren'>) implements device_state_attributes. Please report it to the custom component author.`