### PR TITLE
Add camera notification switch

### DIFF
--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -113,7 +113,7 @@ class WyzeCameraSiren(SirenEntity):
             "identifiers": {
                 (DOMAIN, self._device.mac)
             },
-            "name": self.name,
+            "name": self._device.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._device.product_model
         }

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -308,7 +308,7 @@ class WyzeCameraNotificationSwitch(SwitchEntity):
             "identifiers": {
                 (DOMAIN, self._device.mac)
             },
-            "name": self.name,
+            "name": self._device.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._device.product_model
         }

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -10,7 +10,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
 from wyzeapy import CameraService, SwitchService, Wyzeapy
 from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.switch_service import Switch
@@ -45,7 +45,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 
     switches: List[SwitchEntity] = [WyzeSwitch(switch_service, switch) for switch in
                                     await switch_service.get_switches()]
-    switches.extend([WyzeSwitch(camera_service, switch) for switch in await camera_service.get_cameras()])
+
+    camera_switches = await camera_service.get_cameras()
+    for switch in camera_switches:
+        switches.extend([WyzeSwitch(camera_service, switch)])
+        switches.extend([WyzeCameraNotificationSwitch(camera_service, switch)])
 
     switches.append(WyzeNotifications(client))
 
@@ -159,7 +163,7 @@ class WyzeSwitch(SwitchEntity):
             "identifiers": {
                 (DOMAIN, self._device.mac)
             },
-            "name": self.name,
+            "name": self._device.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._device.product_model
         }
@@ -187,7 +191,10 @@ class WyzeSwitch(SwitchEntity):
     @property
     def name(self):
         """Return the display name of this switch."""
-        return self._device.nickname
+        if type(self._device) is Camera:
+            return f"{self._device.nickname} Power"
+        else:
+            return self._device.nickname
 
     @property
     def available(self):
@@ -282,3 +289,81 @@ class WyzeSwitch(SwitchEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         self._service.unregister_updater(self._device)
+
+
+class WyzeCameraNotificationSwitch(SwitchEntity):
+    """Representation of a Wyze Camera Notification Switch."""
+
+    _available: bool
+
+    def __init__(self, service: CameraService, device: Device):
+        """Initialize a Wyze Notification Switch."""
+        self._service = service
+        self._device = Camera(device.raw_dict)
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "identifiers": {
+                (DOMAIN, self._device.mac)
+            },
+            "name": self.name,
+            "manufacturer": "WyzeLabs",
+            "model": self._device.product_model
+        }
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch."""
+        await self._service.turn_on_notifications(self._device)
+
+        self._device.notify = True
+        self.async_schedule_update_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the switch."""
+        await self._service.turn_off_notifications(self._device)
+
+        self._device.notify = False
+        self.async_schedule_update_ha_state()
+
+    @property
+    def name(self):
+        """Return the display name of this switch."""
+        return f"{self._device.nickname} Notifications"
+
+    @property
+    def available(self):
+        """Return the connection status of this switch."""
+        return self._device.available
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._device.notify
+
+    @property
+    def unique_id(self):
+        """Add a unique ID to the switch."""
+        return "{}-notification_switch".format(self._device.mac)
+
+    @callback
+    def handle_camera_update(self, camera: Camera) -> None:
+        """Update the switch whenever there is an update."""
+        self._device = camera
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for camera updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{CAMERA_UPDATED}-{self._device.mac}",
+                self.handle_camera_update,
+            )
+        )


### PR DESCRIPTION
Adds notification switch per camera to enable/disable push notifications.

Tested on V2 and V3 cameras.

Partially addresses: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/265

Upstream: https://github.com/JoshuaMulliken/wyzeapy/pull/46