### PR TITLE
fix: add availability to siren

### DIFF
--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -89,6 +89,11 @@ class WyzeCameraSiren(SirenEntity):
         return self._device.siren
 
     @property
+    def available(self):
+        """Return the connection status of this switch"""
+        return self._device.available
+
+    @property
     def name(self) -> str:
         return f"{self._device.nickname} Siren"
 


### PR DESCRIPTION
This PR uses the availability of the camera device to determine if the siren entity is available.