### PR TITLE
solve temperature unit problem

### DIFF
--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -106,11 +106,16 @@ class WyzeThermostat(ClimateEntity):
 
     @property
     def temperature_unit(self) -> str:
+        #if self._thermostat.temp_unit == TemperatureUnit.FAHRENHEIT:
+        return TEMP_FAHRENHEIT
+        #return TEMP_CELSIUS
+
+    @property
+    def unit_of_measurement(self) -> str:
         if self._thermostat.temp_unit == TemperatureUnit.FAHRENHEIT:
             return TEMP_FAHRENHEIT
-
-        return TEMP_CELSIUS
-
+        return TEMP_CELSIUS    
+        
     @property
     def hvac_mode(self) -> str:
         # pylint: disable=R1705


### PR DESCRIPTION
the issue is self._thermostat.temp_unit is returning what my device setting. However, even though I set the temperature to Celsius, the actual data of self._thermostat.temperature is still using Fahrenheit. Also, the state doesn't show attribute temperature_unit, so I added unit_of_measurement.