### PR TITLE
Update Lightstrip Effects

### DIFF
--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -11,6 +11,7 @@ WYZE_NOTIFICATION_TOGGLE = f"{DOMAIN}.wyze.notification.toggle"
 
 LOCK_UPDATED = f"{DOMAIN}.lock_updated"
 CAMERA_UPDATED = f"{DOMAIN}.camera_updated"
+LIGHT_UPDATED = f"{DOMAIN}.light_updated"
 # EVENT NAMES
 WYZE_CAMERA_EVENT = "wyze_camera_event"
 

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -178,12 +178,15 @@ class WyzeLight(LightEntity):
                 if kwargs.get(ATTR_EFFECT) == EFFECT_SHADOW:
                     _LOGGER.debug("Setting Shadow Effect")
                     options.append(create_pid_pair(PropertyIDs.LIGHTSTRIP_EFFECTS, str(1)))
+                    self._bulb.effects = "1"
                 elif kwargs.get(ATTR_EFFECT) == EFFECT_LEAP:
                     _LOGGER.debug("Setting Leap Effect")
                     options.append(create_pid_pair(PropertyIDs.LIGHTSTRIP_EFFECTS, str(2)))
+                    self._bulb.effects = "2"
                 elif kwargs.get(ATTR_EFFECT) == EFFECT_FLICKER:
                     _LOGGER.debug("Setting Flicker Effect")
                     options.append(create_pid_pair(PropertyIDs.LIGHTSTRIP_EFFECTS, str(3)))
+                    self._bulb.effects = "3"
 
         _LOGGER.debug("Turning on light")
         self._local_control = self._config_entry.options.get(BULB_LOCAL_CONTROL)
@@ -241,6 +244,10 @@ class WyzeLight(LightEntity):
         if self._bulb.device_params.get("ssid"):
             dev_info["SSID"] = str(self._bulb.device_params.get("ssid"))
         dev_info["Sun Match"] = self._bulb.sun_match
+        dev_info["local_control"] = (
+            self._local_control
+            and not self._bulb.cloud_fallback
+        )
 
         if (
             self._device_type is DeviceTypes.LIGHTSTRIP
@@ -257,10 +264,6 @@ class WyzeLight(LightEntity):
             self._device_type is DeviceTypes.MESH_LIGHT
             or self._device_type is DeviceTypes.LIGHTSTRIP
         ):
-            dev_info["local_control"] = (
-                self._local_control
-                and not self._bulb.cloud_fallback
-            )
 
             if self._bulb.color_mode == '1':
                 dev_info["mode"] = "Color"

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -452,7 +452,7 @@ class WzyeLightstripSwitch(SwitchEntity):
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
-        """Listen for camera updates."""
+        """Listen for light updates."""
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -63,7 +63,6 @@ async def async_setup_entry(
     for switch in camera_switches:
         switches.extend([WyzeSwitch(camera_service, switch)])
         switches.extend([WyzeCameraNotificationSwitch(camera_service, switch)])
-        switches.extend([WyzeCameraMotionSwitch(camera_service, switch)])
 
     switches.append(WyzeNotifications(client))
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -391,7 +391,7 @@ class WzyeLightstripSwitch(SwitchEntity):
     """Music Mode Switch for Wyze Light Strip."""
 
     def __init__(self, service: BulbService, device: Device) -> None:
-        """Initialize a Wyze Notification Switch."""
+        """Initialize a Wyze Music Mode Switch."""
         self._service = service
         self._device = Bulb(device.raw_dict)
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -11,12 +11,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
-from wyzeapy import CameraService, SwitchService, WallSwitchService, Wyzeapy
+from wyzeapy import CameraService, SwitchService, WallSwitchService, Wyzeapy, BulbService
 from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.switch_service import Switch
-from wyzeapy.types import Device, Event
+from wyzeapy.services.bulb_service import Bulb
+from wyzeapy.types import Device, Event, DeviceTypes
 
-from .const import CAMERA_UPDATED
+from .const import CAMERA_UPDATED, LIGHT_UPDATED
 from .const import DOMAIN, CONF_CLIENT, WYZE_CAMERA_EVENT, WYZE_NOTIFICATION_TOGGLE
 from .token_manager import token_exception_handler
 
@@ -27,8 +28,11 @@ SCAN_INTERVAL = timedelta(seconds=30)
 
 # noinspection DuplicatedCode
 @token_exception_handler
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
-                            async_add_entities: Callable[[List[Any], bool], None]) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[List[Any], bool], None],
+) -> None:
     """
     This function sets up the config entry
 
@@ -43,19 +47,30 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
     switch_service = await client.switch_service
     wall_switch_service = await client.wall_switch_service
     camera_service = await client.camera_service
+    bulb_service = await client.bulb_service
 
-    switches: List[SwitchEntity] = [WyzeSwitch(switch_service, switch) for switch in
-                                    await switch_service.get_switches()]
-    
-    switches.extend(WyzeSwitch(wall_switch_service, switch) for switch in
-                    await wall_switch_service.get_switches())
+    switches: List[SwitchEntity] = [
+        WyzeSwitch(switch_service, switch)
+        for switch in await switch_service.get_switches()
+    ]
+
+    switches.extend(
+        WyzeSwitch(wall_switch_service, switch)
+        for switch in await wall_switch_service.get_switches()
+    )
 
     camera_switches = await camera_service.get_cameras()
     for switch in camera_switches:
         switches.extend([WyzeSwitch(camera_service, switch)])
         switches.extend([WyzeCameraNotificationSwitch(camera_service, switch)])
+        switches.extend([WyzeCameraMotionSwitch(camera_service, switch)])
 
     switches.append(WyzeNotifications(client))
+
+    bulb_switches = await bulb_service.get_bulbs()
+    for bulb in bulb_switches:
+        if bulb.type is DeviceTypes.LIGHTSTRIP:
+            switches.extend([WzyeLightstripSwitch(bulb_service, bulb)])
 
     async_add_entities(switches, True)
 
@@ -369,5 +384,79 @@ class WyzeCameraNotificationSwitch(SwitchEntity):
                 self.hass,
                 f"{CAMERA_UPDATED}-{self._device.mac}",
                 self.handle_camera_update,
+            )
+        )
+
+
+class WzyeLightstripSwitch(SwitchEntity):
+    """Music Mode Switch for Wyze Light Strip."""
+
+    def __init__(self, service: BulbService, device: Device) -> None:
+        """Initialize a Wyze Notification Switch."""
+        self._service = service
+        self._device = Bulb(device.raw_dict)
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "identifiers": {(DOMAIN, self._device.mac)},
+            "name": self._device.nickname,
+            "manufacturer": "WyzeLabs",
+            "model": self._device.product_model,
+        }
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch."""
+        await self._service.music_mode_on(self._device)
+
+        self._device.music_mode = True
+        self.async_schedule_update_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the switch."""
+        await self._service.music_mode_off(self._device)
+
+        self._device.music_mode = False
+        self.async_schedule_update_ha_state()
+
+    @property
+    def name(self):
+        """Return the display name of this switch."""
+        return f"{self._device.nickname} Music Mode for Effects"
+
+    @property
+    def available(self):
+        """Return the connection status of this switch."""
+        return self._device.available
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._device.music_mode
+
+    @property
+    def unique_id(self):
+        """Add a unique ID to the switch."""
+        return "{}-music_mode".format(self._device.mac)
+
+    @callback
+    def handle_light_update(self, bulb: Bulb) -> None:
+        """Update the switch whenever there is an update."""
+        self._device = bulb
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for camera updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{LIGHT_UPDATED}-{self._device.mac}",
+                self.handle_light_update,
             )
         )


### PR DESCRIPTION
Wyze recently changed how music mode and effects work with the lightstrips. There are now 3 different effects that can be selected independent of music mode. 

This adds a switch to the lightstrip device to allow music mode to be toggled on and off, which mirrors how the Wyze app works. Also adds the 3 different effect modes as selectable effects from the frontend or scripts.

Upstream: https://github.com/JoshuaMulliken/wyzeapy/pull/55