### PR TITLE
Remove V2 camera siren

### DIFF
--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -41,8 +41,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
     camera_service = await client.camera_service
     sirens = []
     for camera in await camera_service.get_cameras():
-        # The Campan is the only model that I know of that doesn't have a siren
-        if camera.product_model != "WYZECP1_JEF":
+        # The Campan and V2 cameras don't have a siren
+        if camera.product_model not in ["WYZECP1_JEF", "WYZEC1-JZ"]:
             sirens.append(WyzeCameraSiren(camera, camera_service))
 
     async_add_entities(sirens, True)


### PR DESCRIPTION
Here's an easy one for you Josh 😛 

V2 cameras don't have a siren feature, so this stops adding the unused entity for those cameras. 

Previous siren entities will need to be deleted, or delete and reinstall the Wyze integration and they will be removed. 