### PR TITLE
bug: do not create motion switch on unsupported models

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -24,7 +24,7 @@ from .token_manager import token_exception_handler
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 SCAN_INTERVAL = timedelta(seconds=30)
-
+MOTION_SWITCH_UNSUPPORTED = ["GW_BE1"]
 
 # noinspection DuplicatedCode
 @token_exception_handler
@@ -63,7 +63,8 @@ async def async_setup_entry(
     for switch in camera_switches:
         switches.extend([WyzeSwitch(camera_service, switch)])
         switches.extend([WyzeCameraNotificationSwitch(camera_service, switch)])
-        switches.extend([WyzeCameraMotionSwitch(camera_service, switch)])
+        if switch.product_model not in MOTION_SWITCH_UNSUPPORTED:
+            switches.extend([WyzeCameraMotionSwitch(camera_service, switch)])
 
     switches.append(WyzeNotifications(client))
 


### PR DESCRIPTION
doorbell cameras present as cameras but do not support the motion switch toggle. Therefore, we should avoid creating WyzeCameraMotionSwitch entities on these models. 

fixes: https://github.com/JoshuaMulliken/ha-wyzeapi/issues/442