### PR TITLE
Add energy sensors to outdoor plug

### DIFF
--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -434,7 +434,7 @@ class WyzePlugDailyEnergySensor(RestoreSensor):
         new_state = event_data["new_state"]
         old_state = event_data["old_state"]
 
-        if not old_state:
+        if not old_state or not new_state:
             return
 
         updated_energy = (float(new_state.state) - float(old_state.state))


### PR DESCRIPTION
Add total and daily energy sensors to the outdoor plug.

As requested here https://github.com/SecKatie/ha-wyzeapi/issues/425 forever ago and finally ready.

Upstream: https://github.com/SecKatie/wyzeapy/pull/79

A couple notes:

Power usage is combined from both outlets just like in the app.
The power use is displayed on the device called Wyze Plug Outdoor. If you have more than one of these plugs they all show up named the same thing, but you can change that in device settings.
Updates only happen 1-2 times an hour, so if you're comparing to the app there might be slight differences based on when HA pulled the latest usage. 
Because of above, the hourly data in the energy dashboard will not be accurate. 
It only looks at current and last hour’s usage. So when you first install it’ll be at 0 and count up from there. Add it to the energy dashboard to see day/month etc usage.
Now also has a daily usage sensor that resets at midnight.