### PR TITLE
Add Wyze Bulb Cam (HL_BC) light entity support

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -71,7 +71,10 @@ async def async_setup_entry(
     ]
 
     for camera in await camera_service.get_cameras():
-        if (
+        if camera.product_model == "HL_BC":
+            # Wyze Bulb Cam has integrated light
+            lights.append(WyzeCamerafloodlight(camera, camera_service, "bulbcam"))
+        elif (
             camera.product_model == "WYZE_CAKP2JFUS"
             and camera.device_params["dongle_product_model"] == "HL_CFL"
             or camera.product_model in ("LD_CFP", "HL_CFL2")  # Floodlight v2
@@ -426,7 +429,13 @@ class WyzeCamerafloodlight(LightEntity):
     @property
     def name(self) -> str:
         """Return the device name."""
-        return f"{self._device.nickname} {'Lamp Socket' if self._light_type == 'lampsocket' else ('Floodlight' if self._light_type == 'floodlight' else 'Spotlight')}"
+        light_type_names = {
+            "lampsocket": "Lamp Socket",
+            "floodlight": "Floodlight",
+            "spotlight": "Spotlight",
+            "bulbcam": "Light",
+        }
+        return f"{self._device.nickname} {light_type_names.get(self._light_type, 'Light')}"
 
     @property
     def device_info(self):
@@ -463,16 +472,13 @@ class WyzeCamerafloodlight(LightEntity):
     @property
     def icon(self):
         """Return the icon to use in the frontend."""
-
-        return (
-            "mdi:lightbulb"
-            if self._light_type == "lampsocket"
-            else (
-                "mdi:track-light"
-                if self._light_type == "floodlight"
-                else "mdi:spotlight"
-            )
-        )
+        icons = {
+            "lampsocket": "mdi:lightbulb",
+            "floodlight": "mdi:track-light",
+            "spotlight": "mdi:spotlight",
+            "bulbcam": "mdi:lightbulb",
+        }
+        return icons.get(self._light_type, "mdi:lightbulb")
 
     @property
     def color_mode(self):

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/SecKatie/ha-wyzeapi/issues",
   "requirements": [
-    "wyzeapy>=0.5.31,<0.6"
+    "wyzeapy>=0.5.32,<0.6"
   ],
   "version": "0.1.36"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "ha-wyzeapi"
-version = "0.1.35"
+version = "0.1.36rc1"
 description = "A Home Assistant integration for Wyze devices"
 authors = [{ name = "Katie Mulliken", email = "katie@mulliken.net" }]
 license = { text = "Apache-2.0" }
@@ -12,7 +12,7 @@ requires-python = ">=3.13.2,<3.14"
 
 dependencies = [
     "homeassistant>=2025.5.0",
-    "wyzeapy>=0.5.30,<0.6.0",
+    "wyzeapy>=0.5.31rc1,<0.6.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "ha-wyzeapi"
-version = "0.1.36rc1"
+version = "0.1.36"
 description = "A Home Assistant integration for Wyze devices"
 authors = [{ name = "Katie Mulliken", email = "katie@mulliken.net" }]
 license = { text = "Apache-2.0" }
@@ -12,7 +12,7 @@ requires-python = ">=3.13.2,<3.14"
 
 dependencies = [
     "homeassistant>=2025.5.0",
-    "wyzeapy>=0.5.31rc1,<0.6.0",
+    "wyzeapy>=0.5.32,<0.6.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Detect Wyze Bulb Cam (HL_BC) and create a light entity for its integrated bulb
- Add "bulbcam" light type with "Light" name suffix and lightbulb icon
- Refactor `name` and `icon` properties to use dict lookup for cleaner, more maintainable code

## Details
This PR adds Home Assistant light entity support for the Wyze Bulb Cam (model `HL_BC`). The Bulb Cam has an integrated light that can be controlled via the Wyze API.

**Dependencies:** This PR requires [SecKatie/wyzeapy#195](https://github.com/SecKatie/wyzeapy/pull/195) to be merged first, which adds the underlying API support for controlling the Bulb Cam light.

## Test plan
- [ ] Install updated wyzeapy library with Bulb Cam support
- [ ] Verify Bulb Cam light entity appears in Home Assistant
- [ ] Test turning light on/off from Home Assistant
- [ ] Verify state updates when light is controlled from Wyze app

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)