### PR TITLE
fix(deps): require wyzeapy 0.5.31 for Home Assistant 2026.2 compatibility

### DIFF
--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/SecKatie/ha-wyzeapi/issues",
   "requirements": [
-    "wyzeapy>=0.5.30,<0.6"
+    "wyzeapy>=0.5.31,<0.6"
   ],
-  "version": "0.1.35"
+  "version": "0.1.36"
 }


### PR DESCRIPTION
## Summary
- Update wyzeapy dependency to `>=0.5.31,<0.6`
- Bump version to 0.1.36

## Problem
Home Assistant 2026.2.0 upgraded to aiodns 4.0.0, causing a dependency conflict with wyzeapy 0.5.30 which required `aiodns<4.0.0`.

## Solution
wyzeapy 0.5.31 has been released with updated aiodns compatibility (`<5.0.0`). This PR updates ha-wyzeapi to require the fixed version.

Fixes #772