### PR TITLE
fix(lock): prevent KeyError when Lock Bolt coordinator is missing

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -137,6 +137,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         CONF_CLIENT: client,
         "key_id": KEY_ID,
         "api_key": API_KEY,
+        "coordinators": {},
     }
     await setup_coordinators(hass, config_entry, client)
 

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -58,11 +58,17 @@ async def async_setup_entry(
         if lock.product_model != "YD_BT1"
     ]
     lock_bolts = []
+    coordinators = hass.data[DOMAIN][config_entry.entry_id].get("coordinators", {})
     for lock in all_locks:
         if lock.product_model == "YD_BT1":
-            coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinators"][
-                lock.mac
-            ]
+            coordinator = coordinators.get(lock.mac)
+            if coordinator is None:
+                _LOGGER.warning(
+                    "No coordinator found for Lock Bolt %s (%s), skipping",
+                    lock.nickname,
+                    lock.mac,
+                )
+                continue
             lock_bolts.append(WyzeLockBolt(coordinator))
 
     async_add_entities(locks + lock_bolts, True)


### PR DESCRIPTION
## Summary

- Always initialize `coordinators: {}` in `hass.data` at config entry setup so the key is guaranteed to exist regardless of whether any YD_BT1 locks are found
- Replace direct `["coordinators"][lock.mac]` access in `lock.py` with `.get()` calls; log a warning and skip the device instead of crashing the entire lock platform

## Root Cause

A race condition: `setup_coordinators()` calls `get_locks()` and may get an empty or incomplete list (API hiccup, timing), so the `coordinators` key is never added to `hass.data`. When the lock platform later calls `get_locks()` again and finds a YD_BT1 Lock Bolt, the direct dict access crashes with `KeyError: 'coordinators'`, taking down all Wyze lock entities.

## Test plan

- [ ] Verify Wyze Lock (non-YD_BT1) still loads and locks/unlocks correctly
- [ ] Verify Wyze Lock Bolt (YD_BT1) loads when coordinator is present
- [ ] Confirm no crash occurs when coordinator is missing for a YD_BT1 device (warning logged instead)

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)