### PR TITLE
Camera stream

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -42,6 +42,7 @@ PLATFORMS = [
     "cover",
     "number",
     "button",
+    "camera",
 ]  # Fixme: Re add scene
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/wyzeapi/camera.py
+++ b/custom_components/wyzeapi/camera.py
@@ -1,0 +1,521 @@
+"""Wyze Camera integration for Home Assistant."""
+
+import base64
+import json
+import asyncio
+from dataclasses import asdict
+from collections.abc import Callable
+from typing import Any
+import logging
+import uuid
+import re
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.camera import Camera as CameraEntity, CameraEntityFeature
+from homeassistant.components.camera.webrtc import (
+    WebRTCClientConfiguration,
+    WebRTCSendMessage,
+    WebRTCAnswer,
+    WebRTCCandidate,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util.ssl import get_default_context
+from propcache.api import cached_property
+from webrtc_models import RTCConfiguration, RTCIceCandidateInit, RTCIceServer
+from websockets.asyncio.client import connect as websocket_connect
+from wyzeapy import Wyzeapy, CameraService
+from wyzeapy.services.camera_service import Camera
+
+from .const import CAMERA_UPDATED, CONF_CLIENT, DOMAIN
+from .token_manager import token_exception_handler
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@token_exception_handler
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[list[Any], bool], None],
+) -> None:
+    """This function sets up the config entry.
+
+    :param hass: The Home Assistant Instance
+    :param config_entry: The current config entry
+    :param async_add_entities: This function adds entities to the config entry
+    :return:
+    """
+
+    _LOGGER.debug("Creating new Wyze camera component")
+    client: Wyzeapy = hass.data[DOMAIN][config_entry.entry_id][CONF_CLIENT]
+    camera_service = await client.camera_service
+    camera_devices = await camera_service.get_cameras()
+
+    # Create a camera entity for each camera device
+    cameras = []
+    for device in camera_devices:
+        # Update the device to get its zones
+        device = await camera_service.update(device)
+        cameras.extend([WyzeCamera(camera_service, device)])
+
+    for camera in cameras:
+        # Pre-seed the ICE server config by fetching it during setup, so the frontend can collect ICE servers before the offer
+        try:
+            await camera.config_fetch()
+        except Exception as e:
+            # Don't block startup if the config fetch fails, but log the error
+            _LOGGER.warning(
+                "Error fetching WebRTC session configuration for camera %s: %s",
+                camera.name,
+                e,
+            )
+
+    _LOGGER.debug("Wyze camera component setup complete")
+    async_add_entities(cameras, True)
+
+
+class WyzeCamera(CameraEntity):
+    """Representation of a Wyze Camera."""
+
+    def __init__(self, camera_service: CameraService, camera: Camera):
+        """Initialize the camera."""
+        super().__init__()
+        self._camera_service = camera_service
+        self._camera = camera
+        self.name = camera.nickname
+        self._attr_unique_id = camera.mac
+        self.brand = "Wyze"
+        self.model = camera.product_model
+        self.supported_features = CameraEntityFeature.STREAM
+        self._webrtc_provider = None
+        self.sessions: dict[str, WyzeCameraWebRTCSession] = {}
+        self._pending_candidates: dict[str, list[RTCIceCandidateInit]] = {}
+        # Always holds an in-flight Task[dict] for the next config fetch.
+        # _async_get_webrtc_client_configuration reads the result when ready;
+        # async_handle_async_webrtc_offer awaits it to guarantee a fresh config.
+        self._cached_config: dict | None = None
+        self._config_task: asyncio.Task | None = None
+
+    async def config_fetch(self) -> None:
+        """Fetch the WebRTC session configuration for this camera and cache it for future use."""
+        self._cached_config = await self._camera_service.get_stream_info(self._camera)
+        _LOGGER.debug(
+            "Initial fetch of WebRTC session configuration complete for camera %s",
+            self.name,
+        )
+
+    @cached_property
+    def device_info(self) -> DeviceInfo | None:
+        """Return the device info."""
+        return {
+            "identifiers": {(DOMAIN, self._camera.mac)},
+            "name": self._camera.nickname,
+            "manufacturer": "WyzeLabs",
+            "model": self._camera.product_model,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if the camera is available."""
+        return self._camera.available
+
+    @cached_property
+    def is_streaming(self) -> bool:
+        """Return True if the camera is currently streaming."""
+        return self._camera.on
+
+    @callback
+    def handle_camera_update(self, camera: Camera) -> None:
+        """Update the camera whenever there is an update."""
+        self._camera = camera
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for camera updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{CAMERA_UPDATED}-{self._camera.mac}",
+                self.handle_camera_update,
+            )
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the camera is currently on."""
+        return self._camera.on
+
+    async def async_turn_on(self) -> None:
+        """Turn the camera on."""
+        await self._camera_service.turn_on(self._camera)
+
+    async def async_turn_off(self) -> None:
+        """Turn the camera off."""
+        await self._camera_service.turn_off(self._camera)
+
+    async def async_disable_motion_detection(self) -> None:
+        """Disable motion detection."""
+        await self._camera_service.turn_off_motion_detection(self._camera)
+
+    async def async_enable_motion_detection(self) -> None:
+        """Enable motion detection."""
+        await self._camera_service.turn_on_motion_detection(self._camera)
+
+    @property
+    def motion_detection_enabled(self) -> bool | None:
+        """Return True if motion detection is enabled, False if disabled, or None if unknown/not supported."""
+        motion = getattr(self._camera, "motion", None)
+        if isinstance(motion, bool):
+            return motion
+        # Some Wyze camera models / API responses don't expose motion state.
+        # Return None so HA omits/marks the attribute as unknown instead of crashing.
+        return None
+
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
+        """Return bytes of camera image.
+        Currently not implemented"""
+        return None
+
+    def _async_get_webrtc_client_configuration(self) -> WebRTCClientConfiguration:
+        """Return the WebRTC client configuration for this camera, including ICE servers."""
+        # This shouldn't happen, but throw an error if we don't have a config ready yet
+        if self._cached_config is None:
+            raise HomeAssistantError("WebRTC session configuration not available yet")
+
+        config = self._cached_config
+
+        ice_servers = []
+        for server in config.get("ice_servers", []):
+            _LOGGER.debug("Adding ICE server for camera %s: %s", self.name, server)
+            ice_servers.append(
+                RTCIceServer.from_dict(
+                    {
+                        "urls": server["url"],
+                        "username": server["username"],
+                        "credential": server["credential"],
+                    }
+                )
+            )
+
+        _LOGGER.debug("ICE servers for camera %s: %s", self.name, ice_servers)
+        configuration = RTCConfiguration(ice_servers=ice_servers)
+        return WebRTCClientConfiguration(
+            configuration=configuration, data_channel="data"
+        )
+
+    async def async_handle_async_webrtc_offer(
+        self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Handle an incoming WebRTC offer from the frontend."""
+        _LOGGER.debug(
+            "Handling WebRTC offer for camera %s with session ID %s",
+            self.name,
+            session_id,
+        )
+
+        # Always fetch a truly fresh config so the signaling URL and ICE servers
+        # are never stale — KVS signed URLs are single-use and short-lived.
+        config = await self._camera_service.get_stream_info(self._camera)
+
+        # Update cached config with the new ICE servers
+        self._cached_config = config
+        _LOGGER.debug("Fresh config for offer on camera %s: %s", self.name, config)
+
+        self.sessions[session_id] = WyzeCameraWebRTCSession(
+            session_id, self, send_message, config
+        )
+        await self.sessions[session_id].send_offer(offer_sdp)
+
+        pending = self._pending_candidates.pop(session_id, None)
+        if pending:
+            _LOGGER.debug(
+                "Flushing %d buffered ICE candidates for camera %s session %s",
+                len(pending),
+                self.name,
+                session_id,
+            )
+            for cand in pending:
+                await self.sessions[session_id].send_candidate(cand)
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidateInit
+    ) -> None:
+        """Handle an incoming ICE candidate for a WebRTC session."""
+        if session_id not in self.sessions:
+            self._pending_candidates.setdefault(session_id, []).append(candidate)
+            _LOGGER.debug(
+                "Buffered ICE candidate for camera %s session %s (session not ready yet)",
+                self.name,
+                session_id,
+            )
+            return
+
+        await self.sessions[session_id].send_candidate(candidate)
+
+    def close_webrtc_session(self, session_id: str) -> None:
+        """Close a WebRTC session and clean up resources."""
+        _LOGGER.debug("Closing WebRTC session %s", session_id)
+        self._pending_candidates.pop(session_id, None)
+        if session_id in self.sessions:
+            session = self.sessions[session_id]
+            session.close_connection()
+            del self.sessions[session_id]
+
+
+class WyzeCameraWebRTCSession:
+    """Represents a WebRTC session for a Wyze camera."""
+
+    def __init__(
+        self,
+        session_id: str,
+        camera: WyzeCamera,
+        callback: WebRTCSendMessage,
+        config: dict,
+    ):
+        self.session_id = session_id
+        self.camera = camera
+        self.websocket = None  # This will hold the WebSocket connection
+        self.camera_service = None
+        self.callback = callback
+        self.close = None
+        self.lock = asyncio.Lock()
+        self.task = None
+        self.config = config
+        self.sdp_offer = None
+        self.sdp_answer = None
+        # Set once connect() succeeds; send_candidate waits on this instead of reconnecting
+        self._connected = asyncio.Event()
+
+    async def connect(self):
+        """Establish the WebSocket connection to the KVS signaling URL.
+        This is called lazily from send_offer() to ensure we have the latest config
+        and don't connect too early before the offer is ready."""
+        # The signaling_url from get_stream_info() is often *double*-percent-encoded
+        # (e.g. "%253A" instead of "%3A"). We must NOT fully URL-decode it because
+        # that can change SigV4 canonical encoding and make KVS reject the handshake.
+        # Instead, only "undouble" percent-escapes by converting "%25xx" -> "%xx",
+        # leaving "%3A", "%2F", etc. intact.
+        signaling_url = self.config["signaling_url"]
+        for _ in range(3):
+            if "%25" not in signaling_url:
+                break
+            signaling_url = signaling_url.replace("%25", "%")
+        self.websocket = await websocket_connect(
+            signaling_url, ssl=get_default_context(), logger=_LOGGER
+        )
+        _LOGGER.debug(
+            "WebSocket connection established for camera %s with session ID %s",
+            self.camera.name,
+            self.session_id,
+        )
+        self._connected.set()
+        asyncio.create_task(self.run_loop())
+
+    async def send_offer(self, offer_sdp: str):
+        """Send an SDP offer to the Kinesis Video Streams signaling channel."""
+        async with self.lock:
+            if self.websocket is None:
+                _LOGGER.debug("Connecting to websocket from send_offer")
+                await self.connect()
+        if self.websocket is None:
+            raise ConnectionError("WebSocket connection not established")
+        # Create an offer for Kinesis
+        self.sdp_offer = offer_sdp
+        offer = {"type": "offer", "sdp": offer_sdp}
+        payload = {
+            "action": "SDP_OFFER",
+            "recipientClientId": "ada06f08-87f4-4e13-b699-e82db8517ae5",
+            "messagePayload": base64.b64encode(
+                json.dumps(offer, separators=(",", ":")).encode()
+            ).decode(),
+            "correlationId": str(uuid.uuid4()),
+        }
+        str_payload = json.dumps(payload)
+        _LOGGER.debug(
+            "Sending SDP offer for camera %s with session ID %s, %s",
+            self.camera.name,
+            self.session_id,
+            str_payload,
+        )
+        await self.websocket.send(str_payload)
+
+    async def send_candidate(self, candidate: RTCIceCandidateInit):
+        """Send an ICE candidate to the Kinesis Video Streams signaling channel."""
+        # Take RTCIceCandidateInit, convert it to the format in the messagePayload above, and send it to the client using the callback
+        # Wait for send_offer to establish the connection — never reconnect (KVS URLs are single-use)
+        try:
+            await asyncio.wait_for(self._connected.wait(), timeout=10.0)
+        except asyncio.TimeoutError as exc:
+            raise ConnectionError(
+                "WebSocket connection not established within timeout"
+            ) from exc
+        if self.websocket is None:
+            raise ConnectionError("WebSocket connection not established")
+        candidate_dict = asdict(candidate)
+        candidate_payload = {
+            "candidate": candidate_dict["candidate"],
+            "sdpMid": candidate_dict["sdp_mid"],
+            "sdpMLineIndex": candidate_dict["sdp_m_line_index"],
+            "usernameFragment": candidate_dict["user_fragment"],
+        }
+        match = re.search(r"ufrag (\w{4})", candidate_payload["candidate"])
+        if match is not None:
+            candidate_payload["usernameFragment"] = match.group(1)
+        payload = {
+            "action": "ICE_CANDIDATE",
+            "recipientClientId": "ada06f08-87f4-4e13-b699-e82db8517ae5",
+            "messagePayload": base64.b64encode(
+                json.dumps(candidate_payload, separators=(",", ":")).encode()
+            ).decode(),
+        }
+        str_payload = json.dumps(payload)
+        _LOGGER.debug(
+            "Sending ICE candidate for camera %s with session ID %s: %s",
+            self.camera.name,
+            self.session_id,
+            str_payload,
+        )
+        await self.websocket.send(str_payload)
+
+    def close_connection(self):
+        """Close the WebSocket connection to the Kinesis Video Streams signaling channel."""
+        if self.close is not None:
+            self.close()
+
+    def force_correct_sdp_answer(self) -> None:
+        """Force the sdp response to have the valid answer.
+
+        The Kinesis WebRTC Stream responses to certain offers do not
+        follow the spec defined in https://www.ietf.org/rfc/rfc3264.txt
+        An offer of recvonly must be answered with sendonly or inactive.
+        """
+        _LOGGER.debug("Attempt to fix sdp answer...")
+        if isinstance(self.sdp_answer, str) and isinstance(self.sdp_offer, str):
+            sdp_kinds = ["audio", "video", "application"]
+            sdp_directions = ["sendrecv", "sendonly", "recvonly", "inactive"]
+            sdp_pattern = (
+                "m=(?P<kind>{})(.|\n)+?a=(?P<direction>{})(\r|\n|\r\n)".format(
+                    "|".join(sdp_kinds), "|".join(sdp_directions)
+                )
+            )
+
+            sdp_direction_offers = re.finditer(sdp_pattern, self.sdp_offer)
+
+            for offer in sdp_direction_offers:
+                sdp_answers = re.finditer(sdp_pattern, self.sdp_answer)
+                for answer in sdp_answers:
+                    if (
+                        offer.group("kind") == answer.group("kind")
+                        and offer.group("direction") == "recvonly"
+                        and answer.group("direction") == "sendrecv"
+                    ):
+                        correct_answer = re.sub(
+                            "a=sendrecv", "a=sendonly", answer.group(0)
+                        )
+                        _LOGGER.debug("Replacing answer with: %s", str(correct_answer))
+                        self.sdp_answer = self.sdp_answer.replace(
+                            answer.group(0), correct_answer
+                        )
+
+    async def run_loop(self):
+        """Listen for messages from the Kinesis Video Streams signaling channel and handle them appropriately."""
+        if self.websocket is None:
+            raise ConnectionError("WebSocket connection not established")
+
+        loop = asyncio.get_running_loop()
+
+        def close():
+            if self.websocket is not None:
+                return loop.create_task(self.websocket.close())
+            return None
+
+        self.close = close
+        _LOGGER.debug(
+            "run_loop starting for camera %s session %s",
+            self.camera.name,
+            self.session_id,
+        )
+        try:
+            async for message in self.websocket:
+                if len(message) == 0:
+                    _LOGGER.debug(
+                        "Received empty message (type=%s) for camera %s session %s",
+                        type(message).__name__,
+                        self.camera.name,
+                        self.session_id,
+                    )
+                    continue
+                _LOGGER.debug(
+                    "Received message for camera %s with session ID %s: %s",
+                    self.camera.name,
+                    self.session_id,
+                    message,
+                )
+                try:
+                    data = json.loads(message)
+                except json.JSONDecodeError as e:
+                    _LOGGER.error(
+                        "Failed to decode JSON message for camera %s with session ID %s: %s",
+                        self.camera.name,
+                        self.session_id,
+                        e,
+                    )
+                    continue
+                match data.get("messageType"):
+                    case "ICE_CANDIDATE":
+                        # Decode messagePayload (base64 JSON) → RTCIceCandidateInit → WebRTCCandidate
+                        # KVS uses camelCase keys; map them to RTCIceCandidateInit's snake_case fields
+                        candidate_str = base64.b64decode(
+                            data["messagePayload"]
+                        ).decode()
+                        candidate_data = json.loads(candidate_str)
+                        rtccandidate = RTCIceCandidateInit(
+                            candidate=candidate_data["candidate"],
+                            sdp_mid=candidate_data.get("sdpMid"),
+                            sdp_m_line_index=candidate_data.get("sdpMLineIndex"),
+                            user_fragment=candidate_data.get("usernameFragment"),
+                        )
+                        self.callback(WebRTCCandidate(candidate=rtccandidate))
+                    case "SDP_ANSWER":
+                        # Decode messagePayload (base64 JSON with "type"/"sdp" keys) → extract sdp string
+                        answer_str = base64.b64decode(data["messagePayload"]).decode()
+                        try:
+                            answer_obj = json.loads(answer_str)
+                            sdp = answer_obj.get("sdp", answer_str)
+                        except json.JSONDecodeError:
+                            sdp = answer_str
+                        self.sdp_answer = sdp
+                        self.force_correct_sdp_answer()
+                        self.callback(WebRTCAnswer(answer=self.sdp_answer))
+                    case "STATUS_RESPONSE" | "GO_AWAY" | "RECONNECT_ICE_SERVER":
+                        _LOGGER.debug(
+                            "KVS control message '%s' for session %s: %s",
+                            data.get("messageType"),
+                            self.session_id,
+                            data,
+                        )
+                    case other:
+                        _LOGGER.debug(
+                            "Unhandled KVS message type '%s' for session %s: %s",
+                            other,
+                            self.session_id,
+                            data,
+                        )
+        except Exception as e:
+            _LOGGER.error(
+                "run_loop error for camera %s session %s: %s",
+                self.camera.name,
+                self.session_id,
+                e,
+                exc_info=True,
+            )
+        _LOGGER.debug(
+            "run_loop exited for camera %s session %s",
+            self.camera.name,
+            self.session_id,
+        )

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -9,8 +9,10 @@
   "documentation": "https://github.com/SecKatie/ha-wyzeapi#readme",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/SecKatie/ha-wyzeapi/issues",
+  "loggers": ["custom_components.wyzeapi"],
   "requirements": [
-    "wyzeapy>=0.5.33,<0.6"
+    "wyzeapy>=0.5.33,<0.6",
+    "websockets"
   ],
   "version": "0.1.37"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.13.2,<3.14"
 dependencies = [
     "homeassistant>=2025.5.0",
     "wyzeapy>=0.5.33,<0.6.0",
+    "websockets",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -707,6 +707,7 @@ version = "0.1.37"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },
+    { name = "websockets" },
     { name = "wyzeapy" },
 ]
 
@@ -718,6 +719,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.5.0" },
+    { name = "websockets" },
     { name = "wyzeapy", specifier = ">=0.5.33,<0.6.0" },
 ]
 
@@ -1752,6 +1754,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/e8/050ffe3b71ff44d3885eee2bed763ca937e2a30bc950d866f22ba657776b/webrtc_models-0.3.0.tar.gz", hash = "sha256:559c743e5cc3bcc8133be1b6fb5e8492a9ddb17151129c21cbb2e3f2a1166526", size = 9411, upload-time = "2024-11-18T17:43:45.682Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/e7/62f29980c9e8d75af93b642a0c37aa8e201fd5268ba3a7179c172549bac3/webrtc_models-0.3.0-py3-none-any.whl", hash = "sha256:8fddded3ffd7ca837de878033501927580799a2c1b7829f7ae8a0f43b49004ea", size = 7476, upload-time = "2024-11-18T17:43:44.165Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds webRTC stream implementation based off the my.wyze.com/live web implementation

Tested with Wyze v2, v3, and Floodlight pro, but the mechanism appears to be the same (using Kinesis video streams with webRTC) for all wyze web view supported cameras (which is maybe all of them?)

This does use the cloud implementation of streaming, rather than the local tutk interface, but does not require a local streaming server (no go2rtc, etc), as it uses HA's native webRTC implementation.