### PR TITLE
fix(climate): always send setpoints in set_temperature, remove stale-cache dedup guard

### DIFF
--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -208,16 +208,24 @@ class WyzeThermostat(ClimateEntity):
         target_temp_high = kwargs["target_temp_high"]
 
         try:
-            if target_temp_low != self._thermostat.heat_set_point:
-                await self._thermostat_service.set_heat_point(
-                    self._thermostat, int(target_temp_low)
-                )
-                self._thermostat.heat_set_point = int(target_temp_low)
-            if target_temp_high != self._thermostat.cool_set_point:
-                await self._thermostat_service.set_cool_point(
-                    self._thermostat, int(target_temp_high)
-                )
-                self._thermostat.cool_set_point = int(target_temp_high)
+            # Always send setpoints unconditionally rather than guarding against
+            # the cached heat_set_point/cool_set_point value. The equality check
+            # causes a silent no-op whenever the cache is stale (e.g. after a mode
+            # change resets the physical device to firmware defaults, or after a
+            # Wyze cloud/app-driven reset), leaving the physical thermostat at the
+            # wrong setpoint while HA and the Wyze cloud both report the correct one.
+            # The _server_out_of_sync flag compounds this by delaying the cache
+            # refresh by up to 60 s after any command. The underlying API call
+            # (set_iot_prop_by_topic) is idempotent, so always sending is safe.
+            # See: https://github.com/SecKatie/ha-wyzeapi/issues/813
+            await self._thermostat_service.set_heat_point(
+                self._thermostat, int(target_temp_low)
+            )
+            self._thermostat.heat_set_point = int(target_temp_low)
+            await self._thermostat_service.set_cool_point(
+                self._thermostat, int(target_temp_high)
+            )
+            self._thermostat.cool_set_point = int(target_temp_high)
         except (AccessTokenError, ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:


### PR DESCRIPTION
## Summary

Removes the equality guards in `async_set_temperature` that compared the desired setpoint against the integration's in-memory cache before calling `set_heat_point`/`set_cool_point`. When the cache was stale, these guards caused the API calls to be silently skipped — leaving the physical thermostat at the wrong setpoint while HA and the Wyze cloud app both showed the correct value.

Fixes #813. Root cause of #437, #540, #766.

## Root cause

```python
# Before — silently skips when cache matches desired value:
if target_temp_low != self._thermostat.heat_set_point:
    await self._thermostat_service.set_heat_point(...)
    self._thermostat.heat_set_point = int(target_temp_low)  # optimistic update
```

The cache (`heat_set_point`) goes stale in at least three common scenarios:

1. **Mode change resets device firmware defaults.** When switching modes (e.g. `off` → `heat`), the Wyze thermostat resets its local setpoints to internal defaults (typically 73°F heat, 77°F cool). The HA cache still holds the previously-set values. Next call with `target_temp_low=76` sees `76 != 76 = False` → no API call → physical device stays at 73°F.

2. **`_server_out_of_sync` delays cache refresh by 60 s.** After any command the flag causes the next poll to be skipped (only the flag is cleared). The cache doesn't refresh until the *second* poll cycle after a command (~60 s), keeping the false dedup alive.

3. **External resets.** Any Wyze cloud sync, schedule, or app interaction that resets the physical device leaves the cache out of sync with no mechanism to detect it.

**Observed symptom:** HA entity shows `target_temp_low: 76`, Wyze app shows 76°F, physical thermostat hardware shows 73°F. House heats/cools to the wrong temperature or HVAC doesn't run at all.

## Fix

Remove the guards. `set_iot_prop_by_topic` is idempotent — sending the same setpoint twice costs one extra cloud call per invocation but is otherwise harmless. The reliability improvement far outweighs the minor API overhead.

```python
# After — always sends, physical device reliably updated:
await self._thermostat_service.set_heat_point(self._thermostat, int(target_temp_low))
self._thermostat.heat_set_point = int(target_temp_low)
await self._thermostat_service.set_cool_point(self._thermostat, int(target_temp_high))
self._thermostat.cool_set_point = int(target_temp_high)
```

## Verification

Confirmed on two Wyze thermostats (v0.1.36):

1. **Before patch:** sent `set_temperature(low=76)` after a mode change. HA showed `target_temp_low: 76`, Wyze app showed 76°F. Physical thermostat displayed **73°F**. House cooled to 72°F before heater triggered (physical device using its 73°F default with 1°F differential).

2. **Applied patch**, restarted HA.

3. Sent `set_temperature(low=74)`. **Physical thermostat immediately updated to 74°F.** Reverted to correct setpoints — physical devices confirmed the values matched.

## Changes

- `custom_components/wyzeapi/climate.py`: removed 4 lines (equality guards), kept 4 lines (unconditional API calls + cache update)