### PR TITLE
chore(release): 0.1.37

### DIFF
--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -14,5 +14,5 @@
     "wyzeapy>=0.5.33,<0.6",
     "websockets"
   ],
-  "version": "0.1.37rc1"
+  "version": "0.1.37"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "ha-wyzeapi"
-version = "0.1.37rc1"
+version = "0.1.37"
 description = "A Home Assistant integration for Wyze devices"
 authors = [{ name = "Katie Mulliken", email = "katie@mulliken.net" }]
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -821,7 +821,7 @@ wheels = [
 
 [[package]]
 name = "ha-wyzeapi"
-version = "0.1.37rc1"
+version = "0.1.37"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
## Summary

Promote `0.1.37rc1` to the full `0.1.37` release.

## Changes

- Update `pyproject.toml` from `0.1.37rc1` to `0.1.37`
- Update the Home Assistant integration manifest version to `0.1.37`
- Update the editable package version in `uv.lock`

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv lock --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `git diff --check`