### PR TITLE
Fix startup delay from Lock Bolt BLE refresh

### DIFF
--- a/custom_components/wyzeapi/coordinator.py
+++ b/custom_components/wyzeapi/coordinator.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta
 from typing import Dict
 
 from bleak import BleakClient
-from bleak_retry_connector import establish_connection
+from bleak.exc import BleakCharacteristicNotFoundError, BleakError
+from bleak_retry_connector import BleakNotFoundError, establish_connection
 
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
@@ -62,15 +63,24 @@ class WyzeLockBoltCoordinator(DataUpdateCoordinator):
         if self._current_command:
             return self.data
 
-        client = await self._get_ble_client()
-        if client is None:
-            raise UpdateFailed(
-                f"Could not find BLE device {self._lock.nickname} with address {self._mac}. Device may not be in range."
-            )
-
         try:
+            client = await self._get_ble_client()
+            if client is None:
+                raise UpdateFailed(
+                    f"Could not find BLE device {self._lock.nickname} with address {self._mac}. Device may not be in range."
+                )
             value = await client.read_gatt_char(YDBLE_LOCK_STATE_UUID)
             return self._parse_state(value)
+        except BleakCharacteristicNotFoundError as err:
+            raise UpdateFailed(
+                f"Could not read lock state from {self._lock.nickname} ({self._mac}): "
+                f"characteristic {YDBLE_LOCK_STATE_UUID} was not found."
+            ) from err
+        except (BleakError, BleakNotFoundError, TimeoutError) as err:
+            raise UpdateFailed(
+                f"Could not connect to BLE device {self._lock.nickname} with address "
+                f"{self._mac}. Device may not be in range."
+            ) from err
         finally:
             await self._disconnect()
 
@@ -80,23 +90,27 @@ class WyzeLockBoltCoordinator(DataUpdateCoordinator):
             raise Exception(f"Waiting for {self._current_command} command to complete")
         self._current_command = command
         self.async_update_listeners()
-        client = await self._get_ble_client()
-        if client is None:
-            raise Exception(
-                f"Could not find BLE device {self._lock.nickname} with address {self._mac}. Device may not be in range."
-            )
+        try:
+            client = await self._get_ble_client()
+            if client is None:
+                raise Exception(
+                    f"Could not find BLE device {self._lock.nickname} with address {self._mac}. Device may not be in range."
+                )
 
-        # disconnect in 10 seconds in case of error
-        asyncio.create_task(self._disconnect(delay=10))
+            # disconnect in 10 seconds in case of error
+            asyncio.create_task(self._disconnect(delay=10))
 
-        context = {"command": command, "stage": 0}
+            context = {"command": command, "stage": 0}
 
-        async def _handle_uart_rx_context(sender, data):
-            await self._handle_uart_rx(sender, data, client, context)
+            async def _handle_uart_rx_context(sender, data):
+                await self._handle_uart_rx(sender, data, client, context)
 
-        await client.start_notify(YDBLE_UART_RX_UUID, _handle_uart_rx_context)
-        await client.start_notify(YDBLE_LOCK_STATE_UUID, self._handle_state)
-        await self._request_challenge(client)
+            await client.start_notify(YDBLE_UART_RX_UUID, _handle_uart_rx_context)
+            await client.start_notify(YDBLE_LOCK_STATE_UUID, self._handle_state)
+            await self._request_challenge(client)
+        except Exception:
+            await self._disconnect()
+            raise
 
     async def _request_challenge(self, client: BleakClient):
         l2_content = pack_l2_dict(0x91, 0, {10: b"\x27"})

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
                 continue
             lock_bolts.append(WyzeLockBolt(coordinator))
 
-    async_add_entities(locks + lock_bolts, True)
+    async_add_entities(locks + lock_bolts, False)
 
 
 class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
@@ -249,7 +249,15 @@ class WyzeLockBolt(CoordinatorEntity, homeassistant.components.lock.LockEntity):
 
     @property
     def is_locked(self):
+        if self.coordinator.data is None:
+            return None
         return self.coordinator.data["state"] == 1
+
+    @property
+    def available(self):
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        )
 
     async def async_lock(self, **kwargs):
         return await self.coordinator.lock_unlock(command="lock")
@@ -267,4 +275,10 @@ class WyzeLockBolt(CoordinatorEntity, homeassistant.components.lock.LockEntity):
 
     @property
     def state_attributes(self):
+        if self.coordinator.data is None:
+            return {}
         return {"last_operated": self.coordinator.data["timestamp"]}
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.hass.async_create_task(self.coordinator.async_request_refresh())

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -157,7 +157,7 @@ async def async_setup_entry(
             hass, config_entry, devices_to_migrate, device_registry
         )
 
-    async_add_entities(switches, True)
+    async_add_entities(switches, False)
 
 
 async def async_migrate_switch_data(
@@ -226,12 +226,12 @@ class WyzeNotifications(SwitchEntity):
     def __init__(self, client: Wyzeapy) -> None:
         """Initialize the switch."""
         self._client = client
-        self._is_on = False
+        self._is_on = None
         self._uid = WYZE_NOTIFICATION_TOGGLE
         self._just_updated = False
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return if the switch is on."""
         return self._is_on
 
@@ -274,7 +274,7 @@ class WyzeNotifications(SwitchEntity):
     @property
     def available(self):
         """Return the connection status of this switch."""
-        return True
+        return self._is_on is not None
 
     @property
     def unique_id(self):
@@ -287,6 +287,10 @@ class WyzeNotifications(SwitchEntity):
             self._is_on = await self._client.notifications_are_on
         else:
             self._just_updated = False
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_schedule_update_ha_state(True)
 
 
 class WyzeSwitch(SwitchEntity):

--- a/tests/test_startup_refresh.py
+++ b/tests/test_startup_refresh.py
@@ -1,0 +1,118 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from bleak_retry_connector import BleakNotFoundError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+aiousbwatcher = types.ModuleType("aiousbwatcher")
+aiousbwatcher.AIOUSBWatcher = object
+aiousbwatcher.InotifyNotAvailableError = RuntimeError
+sys.modules.setdefault("aiousbwatcher", aiousbwatcher)
+
+serial = types.ModuleType("serial")
+serial_tools = types.ModuleType("serial.tools")
+serial_list_ports = types.ModuleType("serial.tools.list_ports")
+serial_list_ports_common = types.ModuleType("serial.tools.list_ports_common")
+serial_list_ports.comports = lambda: []
+serial_list_ports_common.ListPortInfo = object
+sys.modules.setdefault("serial", serial)
+sys.modules.setdefault("serial.tools", serial_tools)
+sys.modules.setdefault("serial.tools.list_ports", serial_list_ports)
+sys.modules.setdefault("serial.tools.list_ports_common", serial_list_ports_common)
+
+bluetooth = types.ModuleType("homeassistant.components.bluetooth")
+bluetooth.async_ble_device_from_address = lambda *args, **kwargs: None
+bluetooth.async_scanner_count = lambda *args, **kwargs: 1
+sys.modules.setdefault("homeassistant.components.bluetooth", bluetooth)
+
+from custom_components.wyzeapi import lock as lock_platform  # noqa: E402
+from custom_components.wyzeapi.const import CONF_CLIENT, DOMAIN  # noqa: E402
+from custom_components.wyzeapi.coordinator import WyzeLockBoltCoordinator  # noqa: E402
+
+
+class AwaitableValue:
+    def __init__(self, value):
+        self._value = value
+
+    def __await__(self):
+        async def _get_value():
+            return self._value
+
+        return _get_value().__await__()
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_lock_platform_does_not_refresh_entities_before_add(monkeypatch):
+    coordinator = SimpleNamespace()
+    lock_service = SimpleNamespace(
+        get_locks=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    product_model="YD_BT1",
+                    mac="lock-bolt-uuid",
+                    nickname="Front Door",
+                )
+            ]
+        )
+    )
+    client = SimpleNamespace(lock_service=AwaitableValue(lock_service))
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-id": {
+                    CONF_CLIENT: client,
+                    "coordinators": {"lock-bolt-uuid": coordinator},
+                }
+            }
+        }
+    )
+    config_entry = SimpleNamespace(entry_id="entry-id")
+    added = {}
+
+    monkeypatch.setattr(
+        lock_platform,
+        "WyzeLockBolt",
+        lambda lock_bolt_coordinator: ("lock-bolt", lock_bolt_coordinator),
+    )
+
+    def async_add_entities(entities, update_before_add=False):
+        added["entities"] = entities
+        added["update_before_add"] = update_before_add
+
+    run(lock_platform.async_setup_entry(hass, config_entry, async_add_entities))
+
+    assert added["entities"] == [("lock-bolt", coordinator)]
+    assert added["update_before_add"] is False
+
+
+def test_lock_bolt_unknown_until_first_successful_refresh():
+    entity = lock_platform.WyzeLockBolt.__new__(lock_platform.WyzeLockBolt)
+    entity.coordinator = SimpleNamespace(data=None, last_update_success=False)
+
+    assert entity.is_locked is None
+    assert entity.available is False
+    assert entity.state_attributes == {}
+
+
+def test_lock_bolt_ble_connection_failures_become_update_failed():
+    coordinator = WyzeLockBoltCoordinator.__new__(WyzeLockBoltCoordinator)
+    coordinator._current_command = None
+    coordinator.data = None
+    coordinator._lock = SimpleNamespace(nickname="Front Door")
+    coordinator._mac = "00:11:22:33:44:55"
+    coordinator._get_ble_client = AsyncMock(side_effect=BleakNotFoundError("timeout"))
+    coordinator._disconnect = AsyncMock()
+
+    with pytest.raises(
+        UpdateFailed, match="Could not connect to BLE device Front Door"
+    ):
+        run(coordinator._async_update_data())
+
+    coordinator._disconnect.assert_awaited_once()


### PR DESCRIPTION
## Summary

- defer Lock Bolt BLE refreshes until after entity setup completes
- convert BLE connection/read failures into coordinator `UpdateFailed` results
- keep Lock Bolt and notification switch entities unknown/unavailable until their first successful refresh
- add regression tests for startup refresh behavior and BLE failure handling

Fixes #826.

## Root cause

Lock Bolt entities were added with `update_before_add=True`, so Home Assistant waited for the coordinator refresh during platform setup. That refresh can enter `establish_connection(...)` and exhaust BLE retries when a lock is offline or out of range, which makes startup log platform setup delays over 10 seconds.

## Validation

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_startup_refresh.py
UV_CACHE_DIR=/tmp/uv-cache uv run ruff check custom_components/wyzeapi tests
UV_CACHE_DIR=/tmp/uv-cache uv run python -m compileall custom_components/wyzeapi tests
```
